### PR TITLE
feat!: crawler now saves company name and job url

### DIFF
--- a/count.py
+++ b/count.py
@@ -2,8 +2,8 @@ from urllib.parse import urlparse
 from collections import Counter
 
 def count():
-    '''A frequency counter. 
-    
+    '''A frequency counter.
+
     Takes in a file of URLs, each on new lines
     Extracts the base URL, creates dict with base: count
 
@@ -16,7 +16,9 @@ def count():
     with open('hrefs.txt', 'r') as file:
         urls = [line.strip() for line in file]
 
-    base_domains = [extract_base_domain(url) for url in urls]
+    print(urls[0])
+
+    base_domains = [extract_base_domain(url.split('~')[1]) for url in urls]
 
     frequency_counter = Counter(base_domains)
 

--- a/hrefs.txt
+++ b/hrefs.txt
@@ -1,1340 +1,1349 @@
-https://www.taskray.com/careers/
-https://jobs.lever.co/palantir
-https://boards.greenhouse.io/tekmetric
-https://www.linkedin.com/company/sofi/jobs/
-https://esusurent.com/careers/
-https://www.brainsell.com/careers/
-https://www.pandadoc.com/careers/
-https://www.multilingualjobsworldwide.com/jobs
-https://boards.greenhouse.io/baton
-https://www.echobot.com/career/
-https://jobs.lever.co/UrbanJungle
-https://apploi.com/careers/
-https://www.sixfifty.com/about/careers/
-https://blackkite.com/careers/
-https://jobs.jobvite.com/imprivata
-https://teamwork.teamtailor.com/
-https://www.linkedin.com/company/rldatix/jobs/
-https://boards.greenhouse.io/thoropass
-https://xigentsolutions.com/company/careers/
-https://www.recordpoint.com/careers
-https://brightbid.com/work-with-us/#lediga-jobb
-https://elevationhr.com/career/
-https://billd.com/careers/
-https://www.linkedin.com/company/auror/jobs/
-https://highalpha.com/careers/
-https://visit-talent.freshteam.com/jobs
-https://jobs.lever.co/passportshipping
-https://jobs.lever.co/goforward
-https://www.linkedin.com/company/alteryx/jobs/
-https://www.linkedin.com/company/landstar/jobs/
-https://boards.greenhouse.io/hotelengine/
-https://jobs.lever.co/matterport/
-https://www.linkedin.com/company/asksuzy/jobs/
-https://jobs.lever.co/asapp-2
-https://www.linkedin.com/company/bloomberg-industry-group/jobs/
-https://recruitingbypaycor.com/career/CareerHome.action?clientId=8a7883c6894c4dc90189694bd55509d1
-https://boards.greenhouse.io/apaleo/
-https://jobs.funnel.io/
-https://www.linkedin.com/company/meet-marigold/jobs/
-https://union.ai/careers
-https://www.backbase.com/careers/jobs
-https://www.nthventure.com/careers
-https://boards.greenhouse.io/signifyd95
-https://www.linkedin.com/company/lego-group/jobs/
-https://antithesis.breezy.hr/
-https://quix.recruitee.com/
-https://www.zoominfo.com/careers
-https://angel.co/company/conduktor
-https://resources.magicleap.com/en-us/careers
-https://www.linkedin.com/company/milacares/jobs/
-https://panzura.com/company/panzura-careers/
-https://izea.com/company/careers/apply-to-join-izea/
-https://www.linkedin.com/company/intuition-machines-inc./jobs/
-https://www.linkedin.com/company/grant-thornton-llp/jobs/
-https://www.comeet.com/jobs/flare/36.00F
-https://sift.com/careers
-https://www.linkedin.com/company/maersk-group/jobs/
-https://www.scratchpad.com/careers
-https://www.linkedin.com/company/elsevier/jobs/
-https://www.linkedin.com/company/mvmntfreight/jobs/
-https://www.lumavate.com/company/careers
-https://evolutioniq.com/careers/
-https://seon.io/careers/
-https://www.linkedin.com/company/revgenius/jobs/
-https://careers.walmart.com/results?q=Walmart%20Connect&page=1&sort=rank&expand=department,brand,type,rate&jobCareerArea=all
-https://jobs.lever.co/loopreturns
-https://tulip.co/careers
-https://boards.greenhouse.io/amplitude/
-https://jobs.lever.co/Shift%20Markets
-https://flyingcatmarketing.com/careers/
-https://jobs.lever.co/clicktime/
-https://www.linkedin.com/company/smartcatai/jobs/
-https://trimplement.com/work-with-us
-https://charterup.applytojob.com
-https://www.stoutsystems.com/job-search-michigan-and-beyond/
-https://www.joinblvd.com/careers
-https://jobs.ashbyhq.com/Waterplan
-https://boards.greenhouse.io/project44
-https://boards.greenhouse.io/paveakatroveinformationtechnologies
-https://www.apexsystems.com/search-results-usa
-https://www.sixandflow.com/careers/lead-strategist
-https://www.bill.com/about-us/jobs
-https://jobs.lever.co/zopa/
-https://jobs.ashbyhq.com/woflow/
-https://www.linkedin.com/company/cvshealth/jobs/
-https://jobs.lever.co/easypost-2
-https://www.linkedin.com/company/info-tech-research-group/jobs/
-https://careers.getyourguide.com/
-https://jobs.lever.co/findigs
-https://recruiting.ultipro.com/ASC1003/JobBoard/57b0d3c6-a250-9a6a-7787-1093a619de01/?q=&o=postedDateDesc
-https://jobs.lever.co/pivotal
-https://jobs.lever.co/egensolutions?team=Engineering%20and%20Product%20Management
-https://jobs.lever.co/picklerobot
-https://kiteworks.bamboohr.com/jobs
-https://jobs.lever.co/mostly-ai
-https://www.linkedin.com/company/be-cybersmart/jobs/
-https://www.lifeatvena.com/jobs
-https://www.linkedin.com/company/corsha/jobs/
-https://learnamp.com/careers
-https://www.linkedin.com/company/blizzard-entertainment/jobs/
-https://www.parsyl.com/about#team
-https://jobs.lever.co/infinitus
-https://www.adverity.com/careers
-https://nordcloud-career.breezy.hr
-https://flare.io/company/careers/
-https://www.linkedin.com/company/eco-pay/jobs/
-https://jobs.lever.co/1password/
-https://www.amplemarket.com/careers
-https://www.intercom.com/careers?on_pageview_event=careers_footer
-https://www.linkedin.com/company/blueyonder/jobs/
-https://www.linkedin.com/company/invoice-cloud-inc/jobs/
-https://www.linkedin.com/company/lee-hecht-harrison/jobs/
-https://boards.greenhouse.io/jobber/
-https://zapier.com/jobs/
-https://pipe17.com/careers/
-https://www.linkedin.com/jobs/engineer-jobs?trk=organization_guest-browse_jobs
-https://www.leadfeeder.com/jobs/
-https://jobs.lever.co/trolley
-https://jobs.ashbyhq.com/resourcely/
-https://paireyewear.com/pages/careers
-https://www.linkedin.com/company/adp/jobs/
-https://jobs.lever.co/captivateiq/
-https://jobs.lever.co/cloudinary/
-https://www.linkedin.com/company/igt/jobs/
-https://www.linkedin.com/company/pwc/jobs/
-https://www.ashbyhq.com/careers
-https://www.linkedin.com/company/labelbox/jobs/
-https://www.linkedin.com/company/the-new-york-times/jobs/
-http://boards.greenhouse.io/go1us
-https://jobs.lever.co/matchgroup
-https://boards.greenhouse.io/metalab/
-https://www.newbreedrevenue.com/careers
-https://www.tysonmendes.com/careers/
-https://commonsku.com/careers.php
-https://jobs.ashbyhq.com/readme/
-https://www.dealpath.com/careers/
-https://careers.cargurus.com/job-search-results/
-https://fareharbor.com/jobs/all/
-https://www.linkedin.com/company/rye/jobs/
-https://jobs.lever.co/nautical-commerce
-https://careers.toasttab.com/jobs/search
-https://oneup.app.wearecandidly.com/careers
-https://awesomemotive.com/careers/
-https://atlanticdatasecurity.com/company/careers/
-https://www.linkedin.com/company/aquinas-consulting/jobs/
-https://www.applicantpro.com/openings/iapplicants/jobs
-https://boards.greenhouse.io/getbuilt
-https://jobs.lever.co/flexcollegeprep/
-https://jobs.lever.co/paynuity/
-https://www.linkedin.com/company/kaseya/jobs/
-https://www.linkedin.com/company/avaya/jobs/
-https://boards.greenhouse.io/digitalasset/
-https://www.linkedin.com/company/sevenrooms/jobs/
-https://www.leapfin.com/careers/
-https://www.apexon.com/explore-jobs/
-https://aimconsulting.com/careers
-https://www.quorum.us/about/careers/
-https://www.litmos.com/company/careers
-https://www.affirm.com/careers
-https://www.linkedin.com/company/seismic/jobs/
-https://www.linkedin.com/company/motorolasolutions/jobs/
-https://checkr.com/company/careers/open-careers
-https://www.linkedin.com/company/tipalti/jobs/
-https://www.linkedin.com/company/kforce/jobs/
-https://www.linkedin.com/company/zenni-optical/jobs/
-https://www.linkedin.com/company/getcruise/jobs/
-https://www.linkedin.com/company/revpartners/jobs/
-https://jobs.lever.co/biorender/
-https://www.wiz.io/careers
-https://jobs.eu.lever.co/yokoy
-https://seqera.io/careers/
-https://jobs.crelate.com/portal/warriorsrecruiting
-https://www.linkedin.com/company/bok-financial/jobs/
-https://boards.greenhouse.io/couchbaseinc
-https://www.linkedin.com/company/ibm/jobs/
-https://www.linkedin.com/company/adobe/jobs/
-https://www.linkedin.com/company/oreilly/jobs/
-https://www.nlsnow.com/careers/join-us?hsLang=en
-https://boards.greenhouse.io/icapitalnetwork
-https://boards.greenhouse.io/embrace/
-https://www.redditinc.com/careers
-https://zetaglobal.com/about/life-at-zeta/
-https://careers.leadforensics.com/
-https://www.linkedin.com/company/avanade/jobs/
-https://www.livingsecurity.com/careers-and-culture
-https://incode.com/careers/open-positions/
-https://camsys.com/careers-and-culture
-https://www.affinipay.com/careers/
-https://poly.ai/careers/
-https://careers.supermetrics.com/
-https://www.linkedin.com/company/marqeta/jobs/
-https://www.truveta.com/careers/
-https://www.linkedin.com/company/workday/jobs/
-https://www.revenuecat.com/careers/
-https://www.linkedin.com/company/moodysanalytics/jobs/
-https://www.linkedin.com/company/hewlett-packard-enterprise/jobs/
-https://jobs.lever.co/thinkahead
-https://jobs.lever.co/torchdental
-https://www.reversinglabs.com/company/careers
-https://jobs.lever.co/MBRDNA
-https://www.commure.com/careers/
-https://x-team.com/remote-programming-jobs/
-https://www.roller.software/people-and-culture/careers-jobs/
-https://jobs.eu.lever.co/uptempo
-https://jobs.lever.co/canopyservicing/
-https://seamless.ai/company/careers
-https://www.linkedin.com/company/webflow-inc-/jobs/
-https://www.linkedin.com/company/d2l/jobs/
-https://careers.dovercorporation.com/search/?createNewAlert=false&q=systech&locationsearch=&optionsFacetsDD_department=&optionsFacetsDD_facility=
-https://www.linkedin.com/company/cvent/jobs/
-https://www.welcometothejungle.com/en/companies/swan/jobs
-https://careers.mimecast.com/en/jobs/
-https://zuva.ai/careers/
-https://psdcitywide.com/about/careers/
-https://www.linkedin.com/company/intapp/jobs/
-https://www.useanvil.com/careers/
-https://boards.greenhouse.io/ntop
-https://jobs.ashbyhq.com/aurorasolar
-https://www.linkedin.com/company/blackberry/jobs/
-https://3dfortify.com/careers-list/
-https://opentrons.com/about/jobs/
-https://cubelogic.com/careers/
-https://jobs.lever.co/clubhouse/
-https://careers.firstrepublic.com/
-https://careers.archimedesfi.com/
-https://jobs.lever.co/solvhealth
-https://certn.co/careers/
-https://www.grammarly.com/jobs/openings
-https://embarkwithus.wd1.myworkdayjobs.com/embarkcareersite
-https://www.linkedin.com/company/syspro-usa/jobs/
-https://www.glideapps.com/jobs
-https://www.linkedin.com/company/ipullrank/jobs/
-http://careers.remindermedia.com
-https://semgrep.dev/about/careers/
-https://jobs.lever.co/hearsaysystems/
-https://www.linkedin.com/company/tricentis/jobs/
-https://www.thelasallenetwork.com/job-search
-https://complyant.breezy.hr/
-https://www.apollointeractive.com/careers/index.php
-https://jobs.lever.co/clevertap/
-https://jobs.lever.co/covariant/
-https://www.linkedin.com/company/demandlab/jobs/
-https://www.springhealth.com/open-roles
-https://www.linkedin.com/company/siriusxm/jobs/
-https://paywithextend.com/careers
-https://careers.immersivelabs.com/jobs/
-https://www.linkedin.com/company/dick%27s-sporting-goods/jobs/
-https://jobs.lever.co/owner/
-https://www.dataiku.com/careers/
-https://www.banzai.io/careers
-https://jobs.bmc.com/Careers/SearchJobs
-https://www.linkedin.com/company/globallogic/jobs/
-https://www.linkedin.com/jobs/search/?f_C=1544606&geoId=92000000&keywords=advendio&location=Worldwide
-https://parcelperform.freshteam.com/jobs/
-https://ossiumhealth.com/careers
-https://synctera.com/careers
-https://jobs.eu.lever.co/uberall
-https://jobs.lever.co/Archive
-https://www.teamworxsecurity.com/careers/
-https://jobs.ashbyhq.com/leapsome/
-https://www.snagajob.com/career
-https://www.merge.dev/careers
-https://www.varicent.com/cs/c/?cta_guid=094069ca-328e-4457-9392-e60b08e922d2&signature=AAH58kGH0GjZ1VuOEctuYmKUpgcmGEbvKQ&pageId=30755879350&placement_guid=ef2e75a2-f9ed-4f5c-86f8-1c1598a23f78&click=1432afd2-fcfc-487d-a3fe-302bf709052f&hsutk=ade1304308b54e0c37a3a91d2837ac78&canon=https%3A%2F%2Fwww.varicent.com%2Fcompany%2Fcareers&portal_id=6899630&redirect_url=APefjpEOsSFib4GHFRQFp_jG3RpCqSVCviILkt9BS1dy5RMTJgAdFnsoI-IHD6zptW2qYJ44rtqXWcaMwOPIijhEhZS82oQnlmLaAdG64Ddubj5BPbQj-v8&ts=1697577023453&__hstc=104425759.ade1304308b54e0c37a3a91d2837ac78.1697577024141.1697577024141.1697577024141.1&__hssc=104425759.1.1697577024143&__hsfp=2764680836&contentType=standard-page
-https://wanderu.breezy.hr/
-https://strakertranslations.bamboohr.com/careers
-https://www.linkedin.com/company/cato-networks/jobs/
-https://www.ziprecruiter.com/Search-Jobs-Near-Me
-https://boards.greenhouse.io/flowcode
-https://makersitegmbh.recruitee.com
-https://boards.greenhouse.io/shipbobinc/
-https://www.mindex.com/jobs
-https://jobs.lever.co/loopio/
-https://sourcewhale.jobs.personio.com
-https://jobs.lever.co/loftorbital/
-https://www.linkedin.com/company/intelycare/jobs/
-https://boards.greenhouse.io/warbyparker
-https://boards.greenhouse.io/momence
-https://www.linkedin.com/company/joinmultiverse/jobs/
-https://technicaltoolboxes.com/careers/
-https://jobs.ashbyhq.com/rose%20rocket
-https://www.linkedin.com/company/constant-contact/jobs/
-https://www.vicinityenergy.us/careers
-https://www.linkedin.com/company/availity/jobs/
-https://jobs.lever.co/canarytechnologies/
-https://owc.applytojob.com/apply
-https://1800accountant.teamtailor.com/
-https://www.linkedin.com/company/wrike/jobs/
-https://www.linkedin.com/company/freddie-mac/jobs/
-https://www.linkedin.com/company/workable-hr/jobs/
-https://www.bluevine.com/careers
-https://noisedigital.com/careers
-https://www.linkedin.com/company/booking.com/jobs/
-https://www.placer.ai/company/we-are-hiring
-https://jobs.lever.co/canva/
-https://propelleraero.breezy.hr/
-https://boards.greenhouse.io/projectdiscoveryinc
-https://www.n1health.com/about/careers/
-https://www.worktango.com/careers#open-roles
-https://www.linkedin.com/company/pacific-northwest-national-laboratory/jobs/
-https://www.linkedin.com/company/avalara/jobs/
-https://www.linkedin.com/company/ebay/jobs/
-https://www.ninjaone.com/careers/
-https://jobs.lever.co/fundapps/
-https://edpuzzle.com/jobs
-https://unily.teamtailor.com/
-https://boards.greenhouse.io/relaypro
-https://schellgames.com/careers
-https://www.atlashxm.com/careers
-https://frenchagency.biz/jobs/
-https://elephantenergy.com/elephant-careers/
-https://www.linkedin.com/company/factbird-aps/jobs/
-https://www.linkedin.com/company/ansys-inc/jobs/
-https://www.linkedin.com/company/salemmediagroup/jobs/
-https://www.linkedin.com/company/paynearme/jobs/
-https://www.3playmedia.com/company/jobs/
-https://www.gorgias.com/about-us/jobs
-https://hightouch.com/careers
-https://jobs.lever.co/Mediafly
-https://www.linkedin.com/company/butterflymx/jobs/
-https://www.linkedin.com/company/groundswellcloud/jobs/
-https://www.linkedin.com/company/bytedance/jobs/
-https://melodyarc.breezy.hr/
-https://www.procureit.com/careers
-https://www.linkedin.com/company/coolset/jobs/
-https://boards.greenhouse.io/pokemoncareers
-https://www.cleanslatetg.com/who-we-are/careers/
-https://boards.greenhouse.io/bluebeam/
-https://www.allovue.com/careers
-https://jobs.ashbyhq.com/keeper
-https://aeonsemi.com/jobs?locale=en
-https://recruiting.paylocity.com/recruiting/jobs/All/f13aa047-0fd6-4ae1-95d3-058f4f531973/ZYLO-INC
-http://withorb.com/careers
-https://jobs.lever.co/milk-moovement
-https://www.vestwell.com/careers
-https://careers.booztgroup.com/
-https://sees.wd1.myworkdayjobs.com/Sees_Candies
-https://www.linkedin.com/company/faradayio/jobs/
-https://boards.greenhouse.io/alma/
-https://www.comeet.co/jobs/comeet/30.005?__hstc=105140060.122e69be9f88585849f651b81aec04c6.1697008456116.1697008456116.1697008456116.1&__hssc=105140060.1.1697008456117&__hsfp=2764680836
-https://www.linkedin.com/company/sprinklr/jobs/
-https://www.nexhealth.com/careers/open-positions
-https://jobs.ashbyhq.com/resq
-https://coastalcloud.us/coastal-cloud-careers-2-2-2/
-https://optm.com/company/careers#Open-Roles
-https://boards.greenhouse.io/sysdig/
-https://jobs.lever.co/emburse/
-https://terzocloud.freshteam.com/jobs
-https://www.linkedin.com/company/saleo-sales-demo-experience/jobs/
-https://careers.umbra.space/
-https://jobs.lever.co/respondent/
-https://jobs.lever.co/PDQ
-https://www.linkedin.com/company/onetrust/jobs/
-https://www.pica8.com/company/careers/
-https://coherehealth.com/careers/
-https://www.fluencetech.com/careers
-https://www.linkedin.com/company/tekion/jobs/
-https://www.linkedin.com/company/joya-communications/jobs/
-https://www.linkedin.com/company/att/jobs/
-https://jobs.lever.co/q4inc
-https://numastays.com/en/careers
-https://www.crunchtime.com/open-positions
-https://www.linkedin.com/company/nuvoair/jobs/
-https://recruiting.paylocity.com/recruiting/jobs/All/7e700d27-1c17-4273-9855-c424190be932/Design-Interactive-Inc
-https://boards.greenhouse.io/audioeye/
-https://tribliocareers-idg.icims.com/jobs/search?ss=1
-https://mre-consulting.com/careers/
-https://recruiting.ultipro.com/RSA1000RSAS/JobBoard/d9232f43-e112-4585-a5de-af3dbf681e76
-https://jobs.lever.co/modern
-https://jobs.jobvite.com/uplight/jobs
-https://www.dayzerodiagnostics.com/about-us/careers/
-https://jobs.ashbyhq.com/montecarlodata
-https://www.linkedin.com/company/trellixsecurity/jobs/
-https://www.linkedin.com/company/lula-group/jobs/
-https://jobs.cisco.com/jobs/SearchJobs/?source=Cisco+Jobs+Career+Site&tags=CDC+Browse+all+jobs+careers
-https://jobs.lever.co/dexcarehealth
-https://boards.greenhouse.io/figure
-https://careers.conductorone.com
-https://www.linkedin.com/company/clickbank/jobs/
-https://www.linkedin.com/company/autodesk/jobs/
-https://www.linkedin.com/company/purestorage/jobs/
-https://www.linkedin.com/company/splunk/jobs/
-https://drata.com/about/careers
-https://jobs.lever.co/endgame.io
-https://appomni.com/about-us/careers/
-https://block.xyz/careers
-https://www.linkedin.com/company/fidelity-investments/jobs/
-https://gohubtek.com/careers/
-https://www.apptega.com/careers/
-https://www.trulioo.com/apply
-https://www.enterprisedb.com/careers/job-openings
-https://www.vendr.com/careers
-https://www.linkedin.com/company/saascend/jobs/
-https://jobs.lever.co/secureframe/
-https://jobs.lever.co/revivn.com
-https://www.linkedin.com/company/rxvantage/jobs/
-https://virtuozzo.bamboohr.com/careers
-https://www.linkedin.com/company/siemens/jobs/
-https://paper.wd3.myworkdayjobs.com/Paper_Careers
-https://codehs.hire.trakstar.com/
-https://cheq.ai/careers/
-https://trapptechnology.com/careers/careers-portal/
-https://careers.rapid7.com/jobs/search
-https://xselltechnologies.applytojob.com
-https://www.linkedin.com/company/monotype/jobs/
-https://boards.greenhouse.io/superblocks/
-https://www.linkedin.com/company/travelperk/jobs/
-https://jobs.lever.co/frontapp
-https://jobs.lever.co/abridge/
-https://jobs.lever.co/roo/
-https://agilyx.com/careers/
-https://www.linkedin.com/company/mavan/jobs/
-https://www.linkedin.com/company/costco-weareit/jobs/
-https://infotrust.com/careers
-https://www.linkedin.com/company/dialpad/jobs/
-https://www.linkedin.com/company/willowtree/jobs/
-https://www.thousandeyes.com/careers/
-https://bevi.co/careers/
-https://naologic.com/careers/jobs
-https://www.linkedin.com/company/apty/jobs/
-https://forecasthq.bamboohr.com/careers
-https://jobs.lever.co/mindtickle/
-https://www.linkedin.com/company/schoox/jobs/
-https://www.provenir.com/careers/
-https://www.linkedin.com/company/jackpocket/jobs/
-https://www.midwestfamilymadison.com/careers/
-https://careers-spscommerce.icims.com/jobs/7375/strategic-account-executive/job
-https://www.linkedin.com/company/keyence/jobs/
-https://www.linkedin.com/company/new-relic-inc-/jobs/
-https://www.linkedin.com/company/hcltech/jobs/
-https://www.linkedin.com/company/analog-devices/jobs/
-https://jobs.lever.co/tegus
-https://www.linkedin.com/company/riot-games/jobs/
-https://www.linkedin.com/company/remote.com/jobs/
-https://younite-ai.com/careers
-https://www.linkedin.com/company/progyny/jobs/
-https://aa-medical.rippling-ats.com
-https://www.modmed.com/company/careers/
-https://jobs.lever.co/smartcar/
-https://www.threeflow.com/careers
-https://www.gitkraken.com/careers
-https://boards.greenhouse.io/chapter/
-https://jobs.dfinsolutions.com/go/All-Current-Job-Opportunities/4347000/
-https://jobs.lever.co/logicmanager/
-https://jobs.jobvite.com/insurity/jobs/positions
-https://www.aumni.fund/careers
-https://www.mogli.com/about/team
-https://jobs.lever.co/parcellab/
-https://careers.otainsight.com/
-https://www.linkedin.com/company/acronis/jobs/
-https://jobs.lever.co/SafeLease
-https://www.avetta.com/company/careers/careers-list
-https://jobs.ashbyhq.com/Pontosense
-https://www.rippling.com/careers/open-roles
-https://www.hubspot.com/careers/jobs?hubs_signup-cta=careers-nav-cta&hubs_content=www.hubspot.com%2F&hubs_content-cta=null
-https://luminatedata.com/careers/
-https://www.linkedin.com/company/workpathhq/jobs/
-https://www.linkedin.com/company/axios-media/jobs/
-https://secure.entertimeonline.com/ta/VistaPackaging.careers?CareersSearch
-https://fidus.com/careers/
-https://www.linkedin.com/company/betterup/jobs/
-https://www.bothrs.com/careers
-https://macrofab.applytojob.com
-https://www.influxdata.com/careers/
-https://www.papa.com/about/careers
-https://jobs.lever.co/numeris/
-https://jobs.ashbyhq.com/virtuous
-https://jobs.lever.co/synthace/
-https://www.lightico.com/careers/
-https://www.linkedin.com/company/eagleview-technologies-inc/jobs/
-https://jobs.lever.co/simulmedia/
-https://www.infostrux.com/careers
-https://www.linkedin.com/company/flexera/jobs/
-https://canndelta.com/careers/
-https://apply.workable.com/novel-capital
-https://doubleverify.com/careers/current-openings/
-https://www.cloudtalk.io/careers/
-http://careers.datasnipper.com
-https://stake.fish/jobs
-https://jobs.lever.co/livechatinc
-https://hstk.breezy.hr
-https://jobs.lever.co/opengov
-https://birdeye.com/careers/jobsearch/
-https://www.linkedin.com/company/plateiq/jobs/
-https://jobs.seenons.com/
-https://www.linkedin.com/company/enverus-energy/jobs/
-https://boards.greenhouse.io/mural/
-https://jobs.ashbyhq.com/pear
-https://jobs.ashbyhq.com/pathmentalhealth
-https://www.acquia.com/careers/open-positions
-https://jobs.ashbyhq.com/ironcladhq
-https://www.linkedin.com/company/heartland-payment-systems/jobs/
-https://enterprise.craft.co/careers
-https://www.linkedin.com/company/fast-enterprises/jobs/
-https://jobs.lever.co/sonatype/
-https://careers.mpb.com/
-https://careers.confluent.io/search/jobs
-https://www.jackpot.com/careers
-https://www.vidyard.com/careers/
-https://www.linkedin.com/company/crowdstrike/jobs/
-https://jobs.ashbyhq.com/fairsquaremedicare/
-https://www.linkedin.com/company/wpengine/jobs/
-https://jobs.lever.co/logixboard
-https://jobs.lever.co/thunkable/
-https://www.linkedin.com/company/guestready/jobs/
-https://www.ispot.tv/about/careers/listings
-https://www.linkedin.com/company/xendoo/jobs/
-https://boards.greenhouse.io/guardsquare/
-https://www.linkedin.com/company/prolinkworks/jobs/
-https://osf.digital/careers/jobs
-https://jobs.lever.co/matillion/
-https://www.linkedin.com/company/lunio/jobs/
-https://www.braze.com/company/careers
-https://www.linkedin.com/company/f5/jobs/
-https://www.linkedin.com/company/aspireio/jobs/
-https://www.linkedin.com/company/easygenerator/jobs/
-https://jobs.lever.co/formstack/
-https://www.linkedin.com/company/communitybrands/jobs/
-https://freightwavesinc.applytojob.com/apply
-https://www.linkedin.com/company/performyard/jobs/
-https://www.linkedin.com/company/mutinex/jobs/
-https://www.applecart.co/careers
-https://sourcewell.wd1.myworkdayjobs.com/SWCareers
-https://sprockets.ai/careers/
-https://www.linkedin.com/company/paycor/jobs/
-https://jobs.lever.co/percipient
-https://fenix24.com/careers
-https://www.starrez.com/company/careers
-https://jobs.lever.co/Osano
-https://www.ecobee.com/en-us/careers/job-board/
-https://www.linkedin.com/company/coperion/jobs/
-https://www.tomorrow.io/careers/
-https://careers.lmax.com/job-openings/
-https://jobs.lever.co/apex-ai?
-https://www.zayzoon.com/work-with-us
-https://whova.com/jobs/
-https://boards.greenhouse.io/degreed
-https://recruiting.ultipro.com/ARH1000ARH/JobBoard/e5051b40-e91f-fa81-f0bf-ed2e9361f690/?q=&o=postedDateDesc&w=&wc=&we=&wpst=
-https://www.jeeng.com/careers/
-https://jobs.lever.co/xero
-https://web.meetcleo.com/careers
-https://www.linkedin.com/company/khan-academy/jobs/
-https://careers.jfahern.com/?utm_source=careersite&utm_campaign=corpsite
-https://www.linkedin.com/company/venn-technology/jobs/
-https://www.tapmango.com/careers/
-https://optiply.com/nl/vacatures/
-https://www.linkedin.com/company/tvscientific/jobs
-https://recruiting.ultipro.com/PER1013PCLL/JobBoard/b972ff6a-41b7-4e97-9c71-273c2595c77d/?q=&o=postedDateDesc
-https://www.vationventures.com/careers
-https://jobs.lever.co/redaptiveinc/
-https://recruiting2.ultipro.com/STR1017SMINC/JobBoard/e883a137-8797-484c-bf4d-c3d514ec5e38
-https://careers.smartrecruiters.com/BurwoodGroupInc
-https://www.linkedin.com/company/oura/jobs/
-https://jobs.lever.co/stackadapt/
-https://voice123.com/voice-over-jobs
-https://avidbots.com/company/careers/
-https://www.linkedin.com/company/cdw/jobs/
-https://www.linkedin.com/company/allied-global-mkg/jobs/
-https://jobs.lever.co/uniphore/
-https://www.linkedin.com/company/bamboohr/jobs/
-https://www.aclima.io/careers
-https://jobs.lever.co/jumpcloud/
-https://www.linkedin.com/company/cintas/jobs/
-https://jobs.lever.co/doranjones
-https://www.linkedin.com/company/mongodbinc/jobs/
-https://www.make.com/en/careers
-https://jobs.ashbyhq.com/mui/
-https://www.linkedin.com/company/eigenl/jobs/
-https://boards.greenhouse.io/stackline
-https://relx.wd3.myworkdayjobs.com/RiskSolutions
-https://zello.com/careers/
-https://jobs.lever.co/ChefRobotics
-https://www.linkedin.com/company/performline-inc/jobs/
-https://nektar.ai/careers
-https://nuts.com/careers
-https://breezy.hr/attract
-https://www.linkedin.com/company/klaviyo/jobs/
-https://tailscale.com/careers/
-https://feedonomics.applytojob.com
-https://porchgroup.com/careers
-https://certinia.com/about/careers/
-https://www.linkedin.com/company/addisongroup/jobs/
-https://intranetconnections.applytojob.com
-https://sharebite.com/careers
-https://www.eposnow.com/us/careers/open-positions/
-https://autoleap.com/applynow/
-https://vervegroup.recruitee.com
-https://jobs.ashbyhq.com/vantage/
-https://www.linkedin.com/company/silverfort/jobs/
-https://www.plum.io/careers
-https://jobs.lever.co/icertis/
-https://www.hme.com/careers/
-https://www.thoughtful.ai/careers
-https://totango.applytojob.com
-https://www.linkedin.com/company/ascendingllc/jobs/
-https://www.ontotext.com/company/careers/
-https://careers.veeva.com/job-search-results/
-https://www.onlogic.com/company/careers/
-https://careers-drfirst.icims.com/jobs/2023/architect/job
-https://www.auditboard.com/careers/jobs/
-https://www.tractionrec.com/careers
-https://www.linkedin.com/company/rippleofficial/jobs/
-https://www.kimkim.com/careers
-https://www.fastly.com/about/careers/current-openings
-https://jobs.lever.co/digitalremedy/
-https://www.lightspeedhq.com/careers/openings/
-https://www.linkedin.com/company/deltek/jobs/
-https://jobs.lever.co/regalvoice
-https://www.linkedin.com/company/lockheed-martin/jobs/
-https://www.linkedin.com/company/uber-com/jobs/
-https://careers.impactmybiz.com/search/jobs
-https://boards.greenhouse.io/samcarthiring
-https://www.curvature.com/about-us/careers/
-https://www.onemedical.com/careers/all-departments/
-https://www.tucows.com/careers/opportunities
-https://www.forgerock.com/about-us/careers
-https://www.linkedin.com/company/yelp-com/jobs/
-http://chronosphere.io/careers
-https://info.bhgrecovery.com/open-positions
-https://jobs.lever.co/cority/
-https://fluency.applytojob.com
-https://imply.io/positions
-https://www.linkedin.com/company/cgi/jobs/
-https://www.linkedin.com/company/audacy-inc/jobs/
-https://calibermind.com/about/careers/
-https://www.odoo.com/jobs
-https://www.callbox.com/careers
-https://anser.org/careers/opportunity/
-https://www.chameleon.io/jobs
-https://boards.greenhouse.io/tropic
-https://www.plentific.com/en-us/careers
-https://vertigis.recruitee.com/
-https://www.linkedin.com/company/activision/jobs/
-https://boards.greenhouse.io/chicory
-https://www.confiant.com/careers
-https://www.linkedin.com/company/propel-inc/jobs/
-https://www.linkedin.com/company/bonterra-tech/jobs/
-https://www.ownbackup.com/careers/
-https://www.coconutsoftware.com/careers/
-https://www.linkedin.com/company/trustpilot/jobs/
-https://careers.formlabs.com/asia/
-https://www.linkedin.com/company/f1gures/jobs/
-https://www.kimoby.com/careers
-https://boards.greenhouse.io/thanx
-https://boards.greenhouse.io/myfitnesspal/
-https://jobs.jobvite.com/absolute
-https://www.nue.io/company/careers/
-https://jobs.lever.co/h1/
-https://www.quillhash.com/careers
-https://www.healthjoy.com/careers
-https://www.linkedin.com/company/anthologyinc/jobs/
-https://jobs.ashbyhq.com/Geoforce
-https://cognota.com/careers/
-https://reverb.com/page/jobs
-https://jobs.jobvite.com/upland-software
-https://jobs.lever.co/verkada/
-https://www.highradius.com/about/careers/
-https://jobs.lever.co/lumafield/
-https://boards.greenhouse.io/mutiny/
-https://boards.greenhouse.io/bloomreach/
-https://torc.ai/job-board/
-https://jobs.ashbyhq.com/happeo
-https://www.notion.so/careers
-https://www.linkedin.com/company/datadog/jobs/
-https://www.form3.tech/careers
-https://recruiting.ultipro.com/HAN1010/JobBoard/f03ae624-2195-4366-9876-a831dee4af59
-https://boards.greenhouse.io/real
-https://adhoc.team/join/jobs/
-https://jobs.lever.co/nextech
-https://www.linkedin.com/company/basis-technologies/jobs/
-https://www.linkedin.com/company/united-imaging-healthcare/jobs/
-https://www.monitaur.ai/company
-https://joinhandshake.com/career-centers/
-https://www.linkedin.com/company/revolut/jobs/
-https://www.athelas.com/careers
-https://boards.greenhouse.io/embed/job_board?for=groove
-https://jobs.lever.co/collectivei/
-https://boards.greenhouse.io/logicgate/
-https://www.linkedin.com/company/vertex-inc./jobs/
-https://www.linkedin.com/company/gameloft/jobs/
-https://www.linkedin.com/company/preciselydata/jobs/
-https://app.soundstripe.com/careers
-https://boards.greenhouse.io/aiserajobs
-https://www.lusha.com/careers/
-https://www.linkedin.com/company/alianza/jobs/
-https://boards.greenhouse.io/upfort
-https://gocleary.com/careers/
-https://expediagroup.com/careers/default.aspx
-https://www.linkedin.com/company/bloomberg-news/jobs/
-https://jobs.lever.co/colorofchange/
-https://jobs.lever.co/streamsets
-https://www.aktion.com/company/careers/
-https://www.linkedin.com/company/the-trade-desk/jobs/
-https://www.docker.com/career-openings/
-https://careers.konicaminoltaus.com/
-https://boards.greenhouse.io/figma/
-https://jobs.lever.co/cybcube
-https://apply.workable.com/investnext
-https://jobs.lever.co/brightmachines/
-https://shinydocs.applytojob.com
-https://talend.teamtailor.com/
-https://jobs.lever.co/brightwheel/
-https://apply.workable.com/rewiring-america
-https://jobs.ashbyhq.com/ramp
-https://www.linkedin.com/company/crowe/jobs/
-https://jobs.jobvite.com/nutanix
-https://www.reaktor.com/careers
-https://wistia.com/jobs
-https://careers.abnormalsecurity.com/open-roles
-https://www.nice.com/careers/apply
-https://boards.greenhouse.io/avalabs/
-https://boards.greenhouse.io/sigmacomputing/
-https://www.linkedin.com/company/guildeducation/jobs/
-https://stampli.com/careers
-https://incident.io/careers
-https://boards.greenhouse.io/workato
-https://www.linkedin.com/company/busuu-com/jobs/
-https://jobs.lever.co/goodleap
-https://www.plugandplaytechcenter.com/jobs/
-https://jobs.lever.co/appen-2
-https://www.kantox.com/en/careers/?
-https://www.linkedin.com/company/red-river-technology/jobs/
-https://jobs.lever.co/zoox/
-https://www.linkedin.com/company/peloton-interactive-/jobs/
-https://www.softdocs.com/company/careers
-https://www.linkedin.com/company/credit-karma/jobs/
-https://www.linkedin.com/company/preqin/jobs/
-https://profisee.com/job-openings/
-https://boards.greenhouse.io/vonage/
-https://www.thirtycapital.com/careers/
-https://boards.greenhouse.io/tripadvisor
-https://jobs.wetravel.com/
-https://planetdds.applytojob.com
-https://novidea.com/careers/
-https://jobs.lever.co/quantcast/
-https://partstech.com/careers/
-https://www.linkedin.com/company/aamp-of-america/jobs/
-https://www.partly.com/careers/open-roles
-https://careers.eu.m3.com/Creative/m3global
-https://www.ocp.gg/jobs
-https://www.linkedin.com/company/itroninc/jobs/
-https://jobs.lever.co/sounder/
-https://boards.greenhouse.io/plotly/
-https://www.linkedin.com/company/genesys/jobs/
-https://jobs.ashbyhq.com/arcade/
-https://www.linkedin.com/company/dropbox/jobs/
-https://boards.greenhouse.io/beyondtrust/
-https://gohighlevel.com/careers
-https://boards.greenhouse.io/vareto/
-https://www.linkedin.com/company/x/jobs/
-https://www.runzero.com/careers/
-https://www.linkedin.com/company/semrush/jobs/
-https://www.relaynetwork.com/company/careers/
-https://www.sage.com/en-us/company/careers/career-search/
-https://relevant.healthcare/jobs
-https://www.linkedin.com/company/workiva/jobs/
-https://mastercard.wd1.myworkdayjobs.com/CorporateCareers?q=Ekata
-https://flosum.freshteam.com/jobs/
-https://www.weka.io/company/careers/
-https://jobs.deepl.com/
-https://www.linkedin.com/company/codesmithdev/jobs
-https://jobs.lever.co/metabase/
-https://linushealth.com/careers
-https://www.coalitioninc.com/careers/current-openings
-https://www.tcpsoftware.com/careers
-https://www.egress.com/careers/vacancies
-https://www.demandchain.com/careers/
-https://jobs.coop.com/
-https://ipfabric.io/jobs-listing/
-https://www.linkedin.com/company/broadcom/jobs/
-https://www.linkedin.com/company/interface-ai/jobs/
-https://www.linkedin.com/company/hootsuite/jobs/
-https://www.linkedin.com/company/informediq/jobs/
-https://about.fandom.com/careers
-https://www.open-systems.com/careers
-https://www.losant.com/careers
-https://www.shopmonkey.io/careers
-https://samsara.com/company/careers/roles
-https://cloudsmith.com/careers
-https://jobs.lever.co/useinsider
-https://careers.xtm.cloud
-https://www.linkedin.com/company/bd1/jobs/
-https://www.linkedin.com/company/cmimediagroup/jobs/
-https://recruiting.paylocity.com/recruiting/jobs/All/2e9b79ad-c442-43b2-89fe-4fecaa2fde04/Brightly-Software-Inc
-https://www.linkedin.com/company/avantorinc/jobs/
-https://www.linkedin.com/company/plative/jobs/
-https://fusionww.com/careers
-https://jobs.lever.co/tophat/
-https://www.linkedin.com/company/tiaa/jobs/
-https://jobs.lever.co/improbable/
-https://swoonstaffing.com/jobs/
-https://www.linkedin.com/company/abbvie/jobs/
-https://jobs.lever.co/revenueanalytics/
-https://www.linkedin.com/company/skyscanner/jobs/
-https://www.linkedin.com/company/seamgroup/jobs/
-https://www.geckorobotics.com/careers
-https://jobs.ashbyhq.com/notable/
-https://www.zoll.com/contact/careers-at-zoll/careers-search
-https://jobs.lever.co/scratchfinancial/
-https://www.linkedin.com/company/paylocity/jobs/
-https://www.linkedin.com/company/cybsafe-limited/jobs/
-https://duckduckgo.recruitee.com
-https://www.linkedin.com/company/jpmorganchase/jobs/
-https://hyperproof.io/working-at-hyperproof/
-https://silamoney.applytojob.com
-https://www.linkedin.com/company/benchling/jobs/
-https://careers.vetster.com
-https://dashlane.teamtailor.com/
-https://jobs.lever.co/prodigyeducation/
-https://boards.greenhouse.io/visiersolutionsinc
-https://www.logicmonitor.com/careers
-https://jobs.lever.co/cepton/
-https://www.linkedin.com/company/resourceinnovations/jobs/
-https://www.glia.com/jobs
-https://www.linkedin.com/company/john-deere/jobs/
-https://www.guesty.com/careers/
-https://jobs.ashbyhq.com/propelus
-https://jobs.lever.co/qualified
-https://jobs.lever.co/pigment/
-https://boards.greenhouse.io/pixability
-https://jobs.lever.co/super-com
-https://expel.com/about/careers/
-https://trustmachines.co/careers/
-https://365retailmarkets.com/careers/
-https://www.linkedin.com/company/liberty-mutual-insurance/jobs/
-https://www.avoma.com/careers
-https://www.linkedin.com/company/jll/jobs/
-https://www.usekojo.com/careers
-https://jobs.lever.co/airwallex/
-https://www.linkedin.com/company/algolia/jobs/
-https://www.linkedin.com/company/becu/jobs/
-https://www.ontra.ai/careers/
-https://www.linkedin.com/company/pm-group_165501/jobs/
-https://www.linkedin.com/company/at-bay/jobs/
-https://sproutsocial.com/careers/open-positions/
-https://jobs.lever.co/form
-https://www.linkedin.com/company/echo-global-logistics/jobs/
-https://www.spacex.com/careers/jobs/
-https://www.linkedin.com/company/circle-internet-financial/jobs/
-https://www.linkedin.com/company/servicenow/jobs/
-https://careers.flexcar.com/
-https://www.linkedin.com/company/chewy-com/jobs/
-https://boards.greenhouse.io/rfpio
-https://paxos.com/careers/
-https://careers.unbabel.com/
-https://careers.dynatrace.com/jobs/
-https://www.linkedin.com/company/whip-around/jobs/
-https://binti.com/current-openings/
-https://www.sincere.com/careers
-https://www.birdie.care/join-us
-https://jobs.lever.co/agiloft/
-https://boards.greenhouse.io/genies/
-https://prokeep-llc.rippling-ats.com
-https://www.linkedin.com/company/rangle/jobs/
-https://www.ycombinator.com/companies/flutterflow/jobs
-https://boards.greenhouse.io/honeybook
-https://virtualitics.breezy.hr/
-https://www.linkedin.com/company/blackbaud/jobs/
-https://boards.eu.greenhouse.io/gropyus
-https://jobs.lever.co/superannotate
-https://redpanda.com/careers
-https://www.linkedin.com/company/neo-financial/jobs/
-https://superdispatch.breezy.hr/
-https://www.cloudflare.com/careers/jobs/
-https://jobs.lever.co/bazaarvoice/
-https://boards.greenhouse.io/techtalentandstrategy
-https://www.tapcart.com/careers
-https://www.lumos.com/careers
-https://ceribell.com/careers/
-https://investisdigital.bamboohr.com/jobs
-https://www.linkedin.com/company/rubrik-inc/jobs/
-https://www.linkedin.com/company/cmc-global-company-limited/jobs/
-https://www.datagrail.io/careers/
-https://www.sisense.com/careers/
-https://data.world/company/careers/
-https://customer.io/careers
-https://www.hiya.com/careers
-https://reachmobi.bamboohr.com/careers
-https://www.heroku.com/careers
-https://www.linkedin.com/company/onesignal/jobs/
-https://careers.hireology.com/stig
-https://rendered.ai/about/
-https://www.linkedin.com/company/torusrev/jobs/
-https://boards.greenhouse.io/apolloio
-https://recruiting2.ultipro.com/SUP1002SPRM
-https://materialize.com/careers/
-https://www.linkedin.com/company/lightpath/jobs/
-https://www.linkedin.com/company/axis-communications/jobs/
-https://www.classy.org/careers/
-https://www.linkedin.com/company/republic-services-inc/jobs/
-https://saucelabs.com/company/careers
-https://www.pleo.io/en/careers/jobs
-https://www.capellaspace.com/about-us/careers/
-https://www.xembly.com/jobs
-https://boards.greenhouse.io/zip/
-https://prezi.com/jobs/
-https://technologyadvice.com/careers/opportunities/
-https://www.linkedin.com/company/green-irony/jobs/
-https://www.linkedin.com/company/getdeardoc/jobs/
-https://jobs.lever.co/marco
-https://storfund.com/careers/
-https://www.linkedin.com/company/lyra-health/jobs/
-https://www.chainalysis.com/careers/job-openings/
-https://www.linkedin.com/company/fico/jobs/
-https://www.centricsoftware.com/careers/
-https://boards.greenhouse.io/7shifts/
-https://tripactions.com/job-openings
-https://www.linkedin.com/company/atlassian/jobs/
-https://asana.com/jobs/all
-https://www.vestmark.com/careers
-https://www.cognism.com/careers
-https://www.linkedin.com/company/intuit/jobs/
-https://boards.greenhouse.io/taxbit
-https://boards.greenhouse.io/commerceiq
-https://jobs.lever.co/automox/
-https://smartbear.com/company/careers/
-https://clutch.co/careers
-https://www.gaggleamp.com/careers
-https://jobs.ashbyhq.com/futurefitai/
-https://www.reach.vote/jobs/
-https://boards.greenhouse.io/blockrenovation/
-https://jobs.lever.co/vetted/
-https://www.linkedin.com/company/nextdoor-com/jobs/
-https://www.ezcater.com/company/apply/
-https://wasatchproperty.wd1.myworkdayjobs.com/MarketStarCareers
-https://www.uptycs.com/about/career
-https://www.award.co/careers
-https://zerocater.com/about/careers/
-https://www.l2d.co/careers
-https://www.fxinnovation.com/jobs/
-https://www.linkedin.com/company/cribl/jobs/
-https://jobs.lever.co/sunhero/
-https://jobs.lever.co/dixa
-https://www.headspin.io/careers
-https://www.linkedin.com/company/capital-one/jobs/
-https://jobs.ashbyhq.com/moderntreasury/
-https://jobs.lever.co/LinearB
-https://www.linkedin.com/company/clio---cloud-based-legal-technology/jobs/
-https://axestaffingrecruiting.recruitee.com
-https://www.testbox.com/career
-https://recruitingbypaycor.com/career/CareerHome.action?clientId=8a7883c683620a4f018365990ad10010
-https://boards.greenhouse.io/airbase
-https://www.linkedin.com/company/athenahealth/jobs/
-https://www.linkedin.com/company/suse/jobs/
-https://www.anomalo.com/jobs
-https://boards.greenhouse.io/trayio/
-https://www.linkedin.com/company/granite-telecommunications/jobs/
-https://www.linkedin.com/company/creyos/jobs/
-https://clearco.breezy.hr/
-https://www.legitscript.com/about/careers/
-https://www.linkedin.com/company/hillenbrand-inc/jobs/
-https://www.cointracker.io/careers
-https://connatix.com/careers
-https://www.linkedin.com/company/everytable/jobs/
-https://jobs.lever.co/olo/
-https://careers-sonendo.icims.com/jobs/intro?hashed=-626009781&mobile=false&width=1425&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240
-https://www.linkedin.com/company/paychex/jobs/
-https://www.linkedin.com/company/jlltechnologies/jobs/
-https://www.linkedin.com/company/gm-financial/jobs/
-https://www.doxo.com/about/careers/
-https://agentsync.io/careers
-https://jobs.lever.co/kensho
-https://aurora.tech/careers
-https://corp.flipp.com/job-openings/
-https://www.spokeo.com/careers/jobs
-https://www.linkedin.com/company/priority1/jobs/
-https://jobs.ashbyhq.com/hackerone
-https://jobs.lever.co/floqast/
-https://jobs.ashbyhq.com/tango/
-https://www.linkedin.com/company/yahoo/jobs/
-https://www.sprypoint.com/pages/careers/why-sprypoint/
-https://akamaicareers.inflightcloud.com/search
-https://www.linkedin.com/company/cambly/jobs/
-https://apply.workable.com/integral-2
-https://www.linkedin.com/company/turingcom/jobs/
-https://www.getdbt.com/dbt-labs/open-roles/
-https://intrepidstudios.applytojob.com
-https://recruiting.paylocity.com/recruiting/jobs/All/235886f5-63d7-4b56-883a-0fbad71bff8b/MedBridge-Inc
-https://jobs.lever.co/attentive
-https://boards.greenhouse.io/podium81/
-https://www.linkedin.com/company/mercuryhq/jobs/
-https://hginsights.com/about/hg-insights-careers
-https://www.montoux.com/careers
-https://www.linkedin.com/company/warner-bros-discovery/jobs/
-https://www.lacek.com/careers
-https://www.ncontracts.com/careers
-https://www.machinemetrics.com/careers
-https://www.linkedin.com/company/auvik/jobs/
-https://www.clockwork.com/careers/
-https://www.fleetio.com/careers
-https://www.linkedin.com/company/isc2/jobs/
-https://www.linkedin.com/company/transperfect/jobs/
-https://jobs.lever.co/zerofox/
-https://www.linkedin.com/company/yext/jobs/
-https://boards.greenhouse.io/muckrack/
-https://www.neuraflash.com/join-our-team/jobs
-https://spiff.com/careers/
-https://www.linkedin.com/company/broad-institute_2/jobs/
-https://jobs.enel.com/it_IT/careers/JobOpeningsCustomer
-https://www.boatsgroup.com/careers/
-https://www.linkedin.com/company/pax8/jobs/
-https://www.linkedin.com/company/textio/jobs/
-https://otter.ai/careers
-https://www.linkedin.com/company/custom-ink/jobs/
-https://jobs.lever.co/zencore/
-https://jobs.lever.co/Medchart
-https://boards.greenhouse.io/bmnt
-https://jobs.nebula.tv/
-https://www.openphone.com/careers
-https://jmp-sas.icims.com/jobs/search?ss=1&hashed=-435680032
-https://www.mavenclinic.com/careers
-https://careers.smartrecruiters.com/ecovadis
-https://www.newtonx.com/careers/
-https://www.linkedin.com/company/pitchbook/jobs/
-https://freestar.com/careers/
-https://www.linkedin.com/company/peraton/jobs/
-https://jobs.lever.co/narmi/
-https://boards.greenhouse.io/moloco/
-https://www.linkedin.com/company/infor/jobs/
-https://www.linkedin.com/company/zscaler/jobs/
-https://www.hungryroot.com/careers/
-https://redis.com/company/careers/jobs/
-https://mitratech.com/about-us/careers/
-https://careers.smartrecruiters.com/Freshworks
-https://bitly.com/pages/careers
-https://jobs.lever.co/aircall/
-https://www.flocksafety.com/careers
-https://www.veza.com/company/careers
-https://www.linkedin.com/company/sequelio/jobs/
-https://jabu.breezy.hr/
-https://www.linkedin.com/company/eci-software--solutions/jobs/
-https://jobs.lever.co/goodrx/
-https://www.linkedin.com/company/sonrai-security/jobs/
-https://www.saferidehealth.com/careers
-https://www.linkedin.com/company/aes/jobs/
-https://support.recruitee.com
-https://www.linkedin.com/jobs/aviobook-jobs-worldwide?f_C=1003745&trk=top-card_top-card-primary-button-top-card-primary-cta&position=1&pageNum=0
-https://jobs.lever.co/intenseye/
-https://bookipi.com/job-openings/
-https://www.linkedin.com/company/sentinelone/jobs/
-https://boards.greenhouse.io/aquaticcapitalmanagement/
-https://cryptio.co/careers
-https://cleanhub.jobs.personio.de
-https://stackoverflow.com/jobs/companies?so_medium=stackoverflow&so_source=SiteNav
-https://jobs.lever.co/provi/
-https://kobiton.com/careers/
-https://jobs.lever.co/thrillworks
-https://kaleyra.teamtailor.com/
-https://careers.smartrecruiters.com/Brightspeed
-https://www.zyte.com/jobs/
-https://jobs.lever.co/evisort-2
-https://boards.greenhouse.io/fundraiseup
-https://socialfactor.com/agency/#careers
-https://www.linkedin.com/company/huronconsulting/jobs/
-https://careers.yardi.com/openings/
-https://www.linkedin.com/jobs?trk=homepage-basic_directory_jobsHomeUrl
-https://www.ycombinator.com/companies/veryfi-inc/jobs
-https://www.siteline.com/about-us
-https://www.linkedin.com/company/aptiv/jobs/
-https://www.linkedin.com/company/perficient/jobs/
-https://www.linkedin.com/company/accenture/jobs/
-https://www.amla.io/careers/
-https://boards.greenhouse.io/atomicvest
-https://rafay.co/company/careers/
-https://getsignals.ai/careers/
-https://jobs.lever.co/orum/
-https://boards.greenhouse.io/astranis
-https://www.linkedin.com/company/live-chair-health/jobs
-https://jobs.lever.co/newfrontinsurance
-https://www.linkedin.com/company/senditover/jobs/
-https://www.notion.so/ateams/Careers-at-A-Team-4a4af87f3a3b4246bf63d8c1c9201320
-https://clickup.com/careers
-https://coherent.bamboohr.com/jobs
-https://www.linkedin.com/company/trinet/jobs/
-https://www.linkedin.com/company/walkme/jobs/
-https://www.linkedin.com/company/premierinc/jobs/
-https://believer.gg/jobs
-https://www.linkedin.com/company/deloitte/jobs/
-https://www.linkedin.com/company/hopebridge-autism-therapy-centers/jobs/
-https://us63.dayforcehcm.com/CandidatePortal/en-US/pennfostercarrus/SITE/PFCCareerSite
-https://jobs.ashbyhq.com/equi/
-https://render.com/careers
-https://jobs.lever.co/amaze/
-https://orca.security/about/careers/
-https://www.celigo.com/careers/
-https://ejko.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2/requisitions
-https://boards.greenhouse.io/worksighted/
-https://jobs.lever.co/immutable/
-https://retool.com/careers
-https://controltekusa.com/careers
-https://boards.greenhouse.io/recordedfuture/
-https://jobs.lever.co/reibus/
-https://jobs.gartner.com/search-jobs?_its=JTdCJTIydmlkJTIyJTNBJTIyZDlmYTJjZjEtNmQ0Yi00MWRhLTk5NDUtNGI2NGM1ZGEyYmIzJTIyJTJDJTIyc3RhdGUlMjIlM0ElMjJybHR%2BMTY5NzA2MjA5OH5sYW5kfjJfMTY0NjdfZGlyZWN0XzQ0OWU4MzBmMmE0OTU0YmM2ZmVjNWMxODFlYzI4Zjk0JTIyJTJDJTIyc2l0ZUlkJTIyJTNBNDAxMzElN0Q%3D
-https://apply.workable.com/blackcart
-https://buildertrend.com/careers/
-https://www.convertr.io/careers
-https://iterable.com/careers/
-https://www.linkedin.com/company/veeam-software/jobs/
-https://www.neostella.com/careers/
-https://jobs.ashbyhq.com/candidhealth/
-https://www.justworks.com/careers
-https://www.linkedin.com/company/dotdashmeredith/jobs/
-https://www.linkedin.com/company/n-able/jobs/
-https://www.linkedin.com/company/visualping/jobs/
-https://www.linkedin.com/company/varonis/jobs/
-https://www.vicasso.com/company/careers
-https://jobs.lever.co/anyroad/
-https://www.linkedin.com/company/roblox/jobs/
-https://jobs.lever.co/apptegy
-https://careers.calendly.com/jobs/
-https://www.linkedin.com/company/procore-technologies/jobs/
-https://watershed.com/jobs
-https://www.netskope.com/company/careers/open-positions
-https://www.linkedin.com/company/inmarket_1/jobs/
-https://boards.greenhouse.io/attain
-https://boards.greenhouse.io/mycoworks
-https://picovoice.ai/careers/
-https://www.zocdoc.com/about/careers-list/
-https://jobs.lever.co/close.io
-https://www.veloxmedia.com/careers/
-https://boards.greenhouse.io/alphasense/
-https://boards.greenhouse.io/jellyfish/
-https://jobs.ashbyhq.com/deel/
-https://careers.employinc.com/
-https://amarok.com/careers/
-https://jobs.lever.co/docebo/
-https://www.traderinteractive.com/careers/
-https://jobs.lever.co/opslevel/
-https://www.mux.com/jobs
-https://www.mavrck.co/careers/
-https://www.linkedin.com/company/connection-it/jobs/
-https://jobs.paloaltonetworks.com/en/jobs/
-https://jobs.lever.co/goconsensus
-https://www.linkedin.com/company/mcgovern-foundation/jobs/
-https://www.arcadia.com/careers
-https://smithrx.com/careers/
-https://jobs.lever.co/outreach/
-https://www.linkedin.com/company/hellofresh/jobs/
-https://jobs.lever.co/CarbonDirect
-https://www.rebuilt.com/careers
-https://www.storyblok.com/jobs
-https://www.linkedin.com/company/sodexo/jobs/
-https://www.linkedin.com/company/equinix/jobs/
-https://www.linkedin.com/company/tailored-brands-inc-/jobs/
-https://career.oneflow.com/
-https://boards.greenhouse.io/northbeam
-https://jobs.smartrecruiters.com/
-https://cordial.com/careers
-https://slickdeals.net/corp/careers.html
-https://jobs.jobvite.com/apollomed
-https://www.lithic.com/careers
-https://www.askable.com/company/jobs
-https://www.entegee.com/engineering-jobs/
-https://www.linkedin.com/company/coupa-software/jobs/
-https://careers.cloud.com/jobs/search
-https://www.klara.com/careers/jobs
-https://jobs.lever.co/restaurant365/
-https://addigy.bamboohr.com/careers
-https://jobs.lever.co/moogsoft
-https://www.meetsoci.com/about/careers/
-https://jobs.lever.co/patch/
-https://www.linkedin.com/company/perforce/jobs/
-https://tresata.ai/careers/
-https://www.leanix.net/en/company/career/open-positions
-https://www.stayntouch.com/careers/
-https://www.linkedin.com/company/equipmentshare/jobs/
-https://boards.greenhouse.io/connectrn
-https://www.linkedin.com/company/jfrog-ltd/jobs/
-https://www.linkedin.com/company/mckesson/jobs/
-https://www.evenuplaw.com/careers
-https://www.salutesafety.com/join-our-team
-https://insightsoftware.com/careers/
-https://www.linkedin.com/company/nodeslinks/jobs/
-https://www.liquidweb.com/careers/postings/
-https://buildstaffing.com/job-seekers
-https://payitgov.com/careers/
-https://www.linkedin.com/company/latergram-me/jobs/
-https://rootstock-software.breezy.hr
-https://www.linkedin.com/company/thermo-fisher-scientific/jobs/
-https://boards.greenhouse.io/ampla
-https://petalmd.recruitee.com
-https://jobs.lever.co/workos/
-https://jobs.lever.co/promenade
-https://jobs.lever.co/Plooto
-https://www.vajro.com/careers
-https://www.appfolio.com/open-roles
-https://www.descript.com/careers
-https://www.lenusehealth.com/careers
-https://www.linkedin.com/company/plante-moran/jobs/
-https://wd5.myworkdaysite.com/en-US/recruiting/microchiphr/External
-https://www.linkedin.com/company/farm-credit-services-of-america/jobs/
-https://jobs.lever.co/wandb
-https://jobs.gohire.io/wellnessliving-zvcrxvet/
-https://sayvasolutions.com/search-open-positions/
-https://boards.greenhouse.io/sonyinteractiveentertainmentglobal
-https://www.tide.co/careers/
-https://www.linkedin.com/company/certain-affinity/jobs/
-https://www.gle-us.com/careers/
-https://digital.ai/current-job-openings
-https://www.linkedin.com/company/episode-six/jobs/
-https://boards.greenhouse.io/axuall
-https://flextgcareers.ttcportals.com/jobs/search
-https://studioscience.com/careers/
-https://heliumseo.applytojob.com
-https://jobs.lenovo.com/careers/SearchJobs/?jobRecordsPerPage=10&
-https://bemo.rippling-ats.com
-https://careers.juniper.net/
-https://jobs.lever.co/starburstdata
-https://careers.smartrecruiters.com/InformaGroupPlc/informa-markets
-https://jobs.lever.co/securecodewarrior/
-https://gripsintelligence.com/careers
-https://www.linkedin.com/company/t-mobile/jobs/
-https://www.marketone.com/jobs
-https://lydoniatech.com/career/
-https://perkspot12.applytojob.com
-https://engagesmart.com/careers-engagesmart/
-https://eleos.health/career/
-https://www.digicert.com/careers
-https://boards.greenhouse.io/grindr/
-https://www.zerto.com/company/careers/
-https://boards.greenhouse.io/3cloud/
-https://www.linkedin.com/company/dun-&-bradstreet/jobs/
-https://www.talsmart.com/jobs
-https://www.databricks.com/company/careers/open-positions
-https://www.unit21.ai/company/careers
-https://www.jamf.com/about/careers/jobs/
-https://www.levdigital.com/join-the-team
-https://www.linkedin.com/company/protiviti/jobs/
-https://www.linkedin.com/company/stryker/jobs/
-https://leadiq.com/careers
-https://www.outboundengine.com/careers
-https://www.linkedin.com/company/insperity/jobs/
-https://jobs.lever.co/cartodb
-https://www.linkedin.com/company/criteo/jobs/
-https://vetro-fibermap-inc.breezy.hr
-https://www.sumup.com/careers/positions/
-https://www.premise.com/careers/
-https://www.spoton.com/careers/
-https://lightrun.com/careers/
-https://www.linkedin.com/company/biofire/jobs/
-https://www.linkedin.com/company/ecstechhq/jobs/
-https://www.gladly.com/careers/
-https://jobs.pointerstrategy.com.au/
-https://jobs.lever.co/vrchat
-https://www.coveo.com/en/company/careers
-https://careers.bynder.com/
-https://boards.greenhouse.io/ecore/
-https://www.bettercloud.com/job-board/
-https://careers.adyen.com/vacancies
-https://jobs.lever.co/lodgify/
-https://jobs.lever.co/givemomentum
-https://www.linkedin.com/company/fetch-rewards/jobs/
-https://boards.greenhouse.io/hotjar/
-https://www.oxblue.com/company/careers
-https://www.linkedin.com/company/snowflake-computing/jobs/
-https://ascentcloud.io/careers/
-https://www.crossbeam.com/careers/
-https://boards.greenhouse.io/ngrokinc
-https://www.linkedin.com/company/ridewithvia/jobs/
-https://techinsights.applytojob.com
-https://jobs.metlife.com/search/?q=&locationsearch=
-https://www.linkedin.com/company/rossvideo/jobs/
-https://careers.precoa.com/search/jobs
-https://www.linkedin.com/company/mastercard/jobs/
-https://golioth.rippling-ats.com
-https://jobs.lever.co/voltus
-https://www.linkedin.com/company/impactdotcom/jobs/
-https://grin.co/careers/jobs/
-https://www.linkedin.com/company/box/jobs/
-https://jobs.ashbyhq.com/propagate
-https://ismg.careers/careers
-https://www.linkedin.com/company/massmutual-financial-group/jobs/
-https://www.linkedin.com/company/personio/jobs/
-https://careers.cloud.com/jobs/search/sharefile
-https://jobs.lever.co/logikcull/
-https://www.linkedin.com/company/grafana-labs/jobs/
-https://careers-constructconnect.icims.com/jobs/search?hashed=-625918455&mobile=false&width=1140&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240
-https://www.linkedin.com/company/preply/jobs/
-https://www.avicado.com/about/careers/
-https://jobs.lever.co/pingcap/
-https://jobs.ashbyhq.com/runway/
-https://axiomspace.bamboohr.com/careers
-https://www.directshifts.com/careers
-https://jobs.lever.co/secondfrontsystems/
-https://jobs.lever.co/servicerocket/
-https://www.linkedin.com/company/hashtagpaid/jobs/
-https://jobs.lever.co/rover
-https://corp.narvar.com/careers
-https://bestpass.com/about-us/careers
-https://www.linkedin.com/company/ticketnetwork/jobs/
-https://www.linkedin.com/company/michelin/jobs/
-https://property-meld.breezy.hr
-https://www.linkedin.com/company/uber-freight/jobs/
-https://jobs.jobvite.com/onecause/
-https://boards.greenhouse.io/launchdarkly/
-https://jobs.lever.co/klue/
-https://datavant.com/jobs
-https://www.linkedin.com/company/houzz/jobs/
-https://www.linkedin.com/company/sunrun/jobs/
-https://www.traba.work/traba-careers
-https://creditro.com/careers
-https://jobs.ashbyhq.com/cubesoftware
-https://boards.greenhouse.io/axon/
-https://jobs.lever.co/donut
-https://www.linkedin.com/company/workboldly/jobs/
-https://www.moveworks.com/careers
-https://www.linkedin.com/company/motive-inc/jobs/
-https://seequent.csod.com/ux/ats/careersite/1/home?c=seequent
-https://www.linkedin.com/company/settlemint/jobs/
-https://www.rokt.com/careers
-https://www.linkedin.com/company/wavestone/jobs/
-https://boards.greenhouse.io/freshbooks
-https://jobs.lever.co/snowplow
-https://jobs.ashbyhq.com/vanta
-https://www.openspace.ai/careers/
-https://www.budderfly.com/careers/
-https://boards.greenhouse.io/accelerationpartners/
-https://boards.greenhouse.io/audicus
-https://meltwatercareers.ttcportals.com/search/jobs
-https://recruiting.paylocity.com/recruiting/jobs/All/78419728-0f20-46ce-8f93-12ae28d00481/YCHARTS-INC
-https://cto.ai/careers
-https://jobs.emarsys.com
-https://jobs.ashbyhq.com/formenergy/
-https://jobs.ashbyhq.com/census/
-https://www.linkedin.com/company/alegeus-technologies/jobs/
-https://www.golinks.io/careers_list.php
-https://www.linkedin.com/company/bigpanda/jobs/
-https://swirldslabs.com/careers
-https://www.linkedin.com/company/buzzfeed/jobs/
-https://www.linkedin.com/company/nirvana-tech/jobs/
-https://recruiting2.ultipro.com/HAW1006HARI/JobBoard/e2ed3d02-77ba-4ea8-b0b4-a59d2b7c6bb9/?q=&o=postedDateDesc&w=&wc=&we=&wpst=
-https://www.linkedin.com/company/uipath/jobs/
-https://boards.greenhouse.io/flyr
-https://www.classdojo.com/jobs/
-https://acerta.bamboohr.com/jobs/
-https://www.linkedin.com/company/softchoice/jobs/
-https://careers.shawbrook.co.uk/opportunities/
-https://qaconsultants.com/careers/
-https://www.upside.com/about/careers
-https://www.match2one.com/careers/
-https://jobs.lever.co/kodiak
+Shinydocs~https://shinydocs.applytojob.com
+Infinitus Systems, Inc.~https://jobs.lever.co/infinitus
+Tango~https://jobs.ashbyhq.com/tango/
+Sourcewell~https://sourcewell.wd1.myworkdayjobs.com/SWCareers
+Crossbeam~https://www.crossbeam.com/careers/
+Color Of Change~https://jobs.lever.co/colorofchange/
+Synapse~https://jobs.lever.co/synapsefi
+LogicManager~https://jobs.lever.co/logicmanager/
+MacroFab~https://macrofab.applytojob.com
+Trellix~https://www.linkedin.com/company/trellixsecurity/jobs/
+The Believer Company~https://believer.gg/jobs
+OpenSpace~https://www.openspace.ai/careers/
+parcelLab~https://jobs.lever.co/parcellab/
+Klaviyo~https://www.linkedin.com/company/klaviyo/jobs/
+e-Core~https://boards.greenhouse.io/ecore/
+Mutiny~https://boards.greenhouse.io/mutiny/
+ASAPP~https://jobs.lever.co/asapp-2
+SmartRecruiters~https://jobs.smartrecruiters.com/
+Embark~https://embarkwithus.wd1.myworkdayjobs.com/embarkcareersite
+Vantage~https://jobs.ashbyhq.com/vantage/
+GaggleAMP~https://www.gaggleamp.com/careers
+BeyondTrust~https://boards.greenhouse.io/beyondtrust/
+iPullRank~https://www.linkedin.com/company/ipullrank/jobs/
+Plotly~https://boards.greenhouse.io/plotly/
+HCLTech~https://www.linkedin.com/company/hcltech/jobs/
+AppOmni~https://appomni.com/about-us/careers/
+Zscaler~https://www.linkedin.com/company/zscaler/jobs/
+Plenty of Fish~https://jobs.lever.co/matchgroup
+Block Renovation~https://boards.greenhouse.io/blockrenovation/
+IGT~https://www.linkedin.com/company/igt/jobs/
+Cambly Inc.~https://www.linkedin.com/company/cambly/jobs/
+Atlassian~https://www.linkedin.com/company/atlassian/jobs/
+Birdeye~https://birdeye.com/careers/jobsearch/
+Loop~https://jobs.lever.co/loopreturns
+Banzai~https://www.banzai.io/careers
+Echo Global Logistics~https://www.linkedin.com/company/echo-global-logistics/jobs/
+Mercury~https://www.linkedin.com/company/mercuryhq/jobs/
+Sigma Computing~https://boards.greenhouse.io/sigmacomputing/
+GetYourGuide~https://careers.getyourguide.com/
+Konica Minolta Sensing Americas, Inc.~https://careers.konicaminoltaus.com/
+Thoropass~https://boards.greenhouse.io/thoropass
+ReachMobi~https://reachmobi.bamboohr.com/careers
+Real~https://www.linkedin.com/company/realnyc/jobs/
+Applecart~https://www.applecart.co/careers
+Cloudsmith~https://cloudsmith.com/careers
+JumpCloud~https://jobs.lever.co/jumpcloud/
+Brightspeed~https://careers.smartrecruiters.com/Brightspeed
+Comeet~https://www.comeet.co/jobs/comeet/30.005?__hstc=105140060.e20df2b0b93c0083bacdefb3707756a9.1697743172556.1697743172556.1697743172556.1&__hssc=105140060.1.1697743172557&__hsfp=2764680836
+FreshBooks~https://boards.greenhouse.io/freshbooks
+Cloudinary~https://jobs.lever.co/cloudinary/
+Pure Storage~https://www.linkedin.com/company/purestorage/jobs/
+Trustpilot~https://www.linkedin.com/company/trustpilot/jobs/
+SuperAnnotate~https://www.linkedin.com/company/superannotate/jobs
+MetLife~https://jobs.metlife.com/search/?q=&locationsearch=
+Lightico~https://www.lightico.com/careers/
+dbt Labs~https://www.getdbt.com/dbt-labs/open-roles/
+Resourcely~https://jobs.ashbyhq.com/resourcely/
+Watershed~https://watershed.com/jobs
+Arcade~https://jobs.ashbyhq.com/arcade/
+Stryker~https://www.linkedin.com/company/stryker/jobs/
+Informa Markets~https://careers.smartrecruiters.com/InformaGroupPlc/informa-markets
+Tripadvisor~https://boards.greenhouse.io/tripadvisor/
+Prokeep~https://prokeep-llc.rippling-ats.com
+Ripple~https://www.linkedin.com/company/rippleofficial/jobs/
+Magic Leap~https://resources.magicleap.com/en-us/careers
+Modern Treasury~https://jobs.ashbyhq.com/moderntreasury/
+Freestar~https://freestar.com/careers/
+ConductorOne~https://careers.conductorone.com/
+Supermetrics~https://supermetrics.com/careers
+GM Financial~https://www.linkedin.com/company/gm-financial/jobs/
+Seqera Labs~https://seqera.io/careers/
+Askable~https://www.askable.com/company/jobs
+Bluebeam, Inc.~https://www.linkedin.com/company/bluebeam-software/jobs/
+Hotjar~https://www.linkedin.com/company/hotjar/jobs/
+MVMNT~https://www.linkedin.com/company/mvmntfreight/jobs/
+SafeRide Health~https://www.saferidehealth.com/careers
+Later~https://www.linkedin.com/company/latergram-me/jobs/
+Medallion~https://medallion.co/about-medallion/careers
+Avoma~https://www.avoma.com/careers
+Newfront~https://jobs.lever.co/newfrontinsurance
+Coastal Cloud~https://coastalcloud.us/coastal-cloud-careers-2-2-2/
+Urban Jungle Insurance~https://jobs.lever.co/UrbanJungle
+Cleo~https://web.meetcleo.com/careers
+Aptiv~https://www.linkedin.com/company/aptiv/jobs/
+Secure Code Warrior~https://jobs.lever.co/securecodewarrior/
+InvoiceCloud, Inc.~https://www.linkedin.com/company/invoice-cloud-inc/jobs/
+Mogli~https://www.mogli.com/about/team
+Runway~https://jobs.ashbyhq.com/runway/
+ADP~https://www.linkedin.com/company/adp/jobs/
+OpenPhone~https://www.openphone.com/careers
+Patch~https://jobs.lever.co/patch/
+PwC~https://www.linkedin.com/company/pwc/jobs/
+BrainSell~https://www.brainsell.com/careers/
+Avaya~https://www.linkedin.com/company/avaya/jobs/
+365 Retail Markets~https://365retailmarkets.com/careers/
+Rafay~https://rafay.co/company/careers/
+TaskRay~https://www.taskray.com/careers/
+M3 Global Research~https://careers.eu.m3.com/Creative/m3global
+Hootsuite~https://www.linkedin.com/company/hootsuite/jobs/
+Costco IT~https://www.linkedin.com/company/costco-weareit/jobs/
+Midwest Family Marketing~https://www.midwestfamilymadison.com/careers/
+Apollo.io~https://boards.greenhouse.io/apolloio/
+DearDoc~https://www.linkedin.com/company/getdeardoc/jobs/
+Info-Tech Research Group~https://www.linkedin.com/company/info-tech-research-group/jobs/
+Muck Rack~https://www.linkedin.com/company/muckrack/jobs/
+Unily~https://unily.teamtailor.com/
+Edpuzzle~https://edpuzzle.com/jobs
+Meltwater~https://www.linkedin.com/company/meltwater/jobs/
+Snowflake~https://www.linkedin.com/company/snowflake-computing/jobs/
+Spiff Inc~https://spiff.com/careers/
+Smartcat~https://www.linkedin.com/company/smartcatai/jobs/
+Priority1~https://www.linkedin.com/company/priority1/jobs/
+Panzura~https://panzura.com/company/panzura-careers/
+Apollo Interactive~https://www.linkedin.com/company/apollo-interactive/jobs/
+Nautical Commerce~https://jobs.lever.co/nautical-commerce
+Go1~http://boards.greenhouse.io/go1us
+3Cloud~https://boards.greenhouse.io/3cloud/
+Klue~https://jobs.lever.co/klue/
+Jellyfish~https://boards.greenhouse.io/jellyfish/
+Digital Asset~https://boards.greenhouse.io/digitalasset/
+Simulmedia~https://jobs.lever.co/simulmedia/
+AffiniPay~https://www.affinipay.com/careers/
+Acerta~https://acerta.bamboohr.com/jobs/
+Noise Digital Inc.~https://noisedigital.com/careers
+Geoforce~https://jobs.ashbyhq.com/Geoforce
+Thermo Fisher Scientific~https://www.linkedin.com/company/thermo-fisher-scientific/jobs/
+Flock Safety~https://www.flocksafety.com/careers
+The AES Corporation~https://www.linkedin.com/company/aes/jobs/
+Classy~https://www.linkedin.com/company/stayclassy/jobs/
+trimplement GmbH~https://trimplement.com/work-with-us
+Orca Security~https://orca.security/about/careers/
+Grindr~https://boards.greenhouse.io/grindr/
+Carbon Direct~https://www.carbon-direct.com/careers
+Atlas~https://www.atlashxm.com/careers
+Pipe17~https://pipe17.com/careers/
+Oneflow~https://www.linkedin.com/company/oneflowcom/jobs/
+Uptempo~https://jobs.eu.lever.co/uptempo
+Tellent (formerly Recruitee)~https://support.recruitee.com
+Prodigy Education~https://jobs.lever.co/prodigyeducation/
+Siteline~https://www.siteline.com/about-us
+Arhaus~https://recruiting.ultipro.com/ARH1000ARH/JobBoard/e5051b40-e91f-fa81-f0bf-ed2e9361f690/?q=&o=postedDateDesc&w=&wc=&we=&wpst=
+Farm Credit Services of America~https://www.linkedin.com/company/farm-credit-services-of-america/jobs/
+ECI Software Solutions~https://www.linkedin.com/company/eci-software--solutions/jobs/
+Preqin~https://www.linkedin.com/company/preqin/jobs/
+CleverTap~https://jobs.lever.co/clevertap/
+Nebula~https://jobs.nebula.tv/
+Ekata, a Mastercard company~https://mastercard.wd1.myworkdayjobs.com/CorporateCareers?q=Ekata
+Zoox~https://jobs.lever.co/zoox/
+Osano~https://jobs.lever.co/Osano
+Vendr~https://www.vendr.com/careers
+Liberty Mutual Insurance~https://www.linkedin.com/company/liberty-mutual-insurance/jobs/
+Carrus~https://us63.dayforcehcm.com/CandidatePortal/en-US/pennfostercarrus/SITE/PFCCareerSite
+Kforce Inc~https://www.linkedin.com/company/kforce/jobs/
+FLYR~https://boards.greenhouse.io/flyr
+Responsive~https://www.linkedin.com/company/responsiveio/jobs/
+Vetster Inc.~https://careers.vetster.com/
+commonsku~https://commonsku.com/careers.php
+Premier Inc.~https://www.linkedin.com/company/premierinc/jobs/
+Ontotext~https://www.ontotext.com/company/careers/
+Nextech Systems~https://jobs.lever.co/nextech
+Archive~https://jobs.lever.co/Archive
+Egen~https://jobs.lever.co/egensolutions?team=Engineering%20and%20Product%20Management
+Ironclad~https://jobs.ashbyhq.com/ironcladhq
+Lula Group~https://www.linkedin.com/company/lula-group/jobs/
+OxBlue~https://www.oxblue.com/company/careers
+Acquia~https://www.acquia.com/careers/open-positions
+Tresata~https://tresata.ai/careers/
+Donnelley Financial Solutions (DFIN)~https://jobs.dfinsolutions.com/go/All-Current-Job-Opportunities/4347000/
+HeadSpin~https://www.headspin.io/careers
+Monitaur~https://www.monitaur.ai/company
+Astranis Space Technologies~https://boards.greenhouse.io/astranis
+Weights & Biases~https://jobs.lever.co/wandb
+MelodyArc~https://melodyarc.breezy.hr/
+Peraton~https://www.linkedin.com/company/peraton/jobs/
+LHH~https://www.linkedin.com/company/lee-hecht-harrison/jobs/
+BlackBerry~https://www.linkedin.com/company/blackberry/jobs/
+RecordPoint~https://www.recordpoint.com/careers
+Informed.IQ~https://www.linkedin.com/company/informediq/jobs/
+intenseye~https://jobs.lever.co/intenseye/
+Feedonomics~https://www.linkedin.com/company/feedonomics/jobs/
+Numeris~https://jobs.lever.co/numeris/
+InfoTrust~https://infotrust.com/careers
+Voice123~https://voice123.com/voice-over-jobs
+Tucows~https://www.tucows.com/careers/opportunities
+Hungryroot~https://www.hungryroot.com/careers/
+Heartland~https://www.linkedin.com/company/heartland-payment-systems/jobs/
+Fleetio~https://www.fleetio.com/careers
+High Alpha~https://highalpha.com/careers/
+X, the moonshot factory~https://www.linkedin.com/company/x/jobs/
+Nektar.ai~https://nektar.ai/careers
+Tulip Interfaces~https://tulip.co/careers
+Endgame~https://www.linkedin.com/company/endgamelabs/jobs/
+Liquid Web~https://www.liquidweb.com/careers/postings/
+Sisense~https://www.sisense.com/careers/
+Census~https://jobs.ashbyhq.com/census/
+Whova~https://whova.com/jobs/
+ezCater~https://boards.greenhouse.io/ezcaterinc
+ServiceRocket~https://jobs.lever.co/servicerocket/
+Boldly Remote Staffing~https://www.linkedin.com/company/workboldly/jobs/
+Tekmetric~https://boards.greenhouse.io/tekmetric
+Uberall~https://jobs.eu.lever.co/uberall
+Dataiku~https://www.dataiku.com/careers/
+Intrepid Studios, Inc~https://intrepidstudios.applytojob.com
+Apploi~https://apploi.com/careers/
+Toast~https://careers.toasttab.com/jobs/search
+Broad Institute of MIT and Harvard~https://www.linkedin.com/company/broad-institute_2/jobs/
+Mila Cares~https://milacares.com/careers
+EcoVadis~https://careers.smartrecruiters.com/ecovadis
+Spring Health~https://www.springhealth.com/open-roles
+CMI Media Group~https://www.linkedin.com/company/cmimediagroup/jobs/
+EigenLayer~https://www.linkedin.com/company/eigenl/jobs/
+Seismic~https://www.linkedin.com/company/seismic/jobs/
+Hubtek~https://gohubtek.com/careers/
+AAMP Global~https://www.linkedin.com/company/aamp-of-america/jobs/
+Pickle Robot Company~https://jobs.lever.co/picklerobot
+Boulevard~https://www.joinblvd.com/careers
+Black Kite~https://black-kite.rippling-ats.com
+The Pokémon Company International~https://boards.greenhouse.io/pokemoncareers
+Veza~https://www.veza.com/company/careers
+Klara~https://www.klara.com/careers/jobs
+BD~https://www.linkedin.com/company/bd1/jobs/
+Freshworks~https://careers.smartrecruiters.com/Freshworks
+Microchip Technology Inc.~https://wd5.myworkdaysite.com/en-US/recruiting/microchiphr/External
+Hearsay Systems~https://jobs.lever.co/hearsaysystems/
+TapMango~https://www.tapmango.com/careers/
+Sage Intacct, Inc.~https://www.sage.com/en-us/company/careers/career-search/
+Paychex~https://www.linkedin.com/company/paychex/jobs/
+DeepL~https://jobs.deepl.com/
+Emergent Holdings~https://ejko.fa.us2.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_2/requisitions
+SourceWhale~https://sourcewhale.jobs.personio.com/
+Binti~https://binti.com/current-openings/
+Triptych~https://www.l2d.co/careers
+Fastly~https://www.fastly.com/about/careers/current-openings
+Republic Services~https://www.linkedin.com/company/republic-services-inc/jobs/
+Cisco~https://jobs.cisco.com/jobs/SearchJobs/?source=Cisco+Jobs+Career+Site&tags=CDC+Browse+all+jobs+careers
+Close~https://jobs.lever.co/close.io
+Arcadia~https://www.arcadia.com/careers
+Quantcast~https://jobs.lever.co/quantcast/
+Insurity~https://jobs.jobvite.com/insurity/jobs/positions
+Canopy~https://www.linkedin.com/company/canopyservicing/jobs/
+PitchBook~https://www.linkedin.com/company/pitchbook/jobs/
+Couchbase~https://boards.greenhouse.io/couchbaseinc
+Voltus~https://jobs.lever.co/voltus
+Otter.ai~https://otter.ai/careers
+Milk Moovement~https://jobs.lever.co/milk-moovement
+Affirm~https://www.affirm.com/careers
+Vestmark~https://www.vestmark.com/careers
+Call Box~https://www.callbox.com/careers
+AutoLeap~https://autoleap.com/applynow/
+Amplemarket~https://www.amplemarket.com/careers
+Capella Space~https://www.capellaspace.com/about-us/careers/
+Appen~https://jobs.lever.co/appen-2
+Labelbox~https://labelbox.com/company/careers
+Fluence Technologies~https://www.fluencetech.com/careers
+WEKA~https://www.weka.io/company/careers/
+TechnologyAdvice~https://technologyadvice.com/careers/opportunities/
+Quix~https://quix.recruitee.com/
+ecobee~https://www.ecobee.com/en-us/careers/job-board/
+Shift Markets~https://jobs.lever.co/Shift%20Markets
+StackAdapt~https://jobs.lever.co/stackadapt/
+Softchoice~https://www.linkedin.com/company/softchoice/jobs/
+Kensho Technologies~https://jobs.lever.co/kensho
+Marco Polo~https://www.linkedin.com/company/joya-communications/jobs/
+ReminderMedia~http://careers.remindermedia.com/
+Make~https://www.make.com/en/careers
+Pixability~https://boards.greenhouse.io/pixability
+Truveta~https://www.truveta.com/careers
+Thanx~https://boards.greenhouse.io/thanx
+Dixa~https://www.linkedin.com/company/dixa/jobs/
+Boats Group~https://www.boatsgroup.com/careers/
+Aquinas Consulting~https://www.linkedin.com/company/aquinas-consulting/jobs/
+Apty~https://www.linkedin.com/company/apty/jobs/
+Coalition, Inc.~https://www.coalitioninc.com/careers/current-openings
+Ross Video~https://www.linkedin.com/company/rossvideo/jobs/
+Uniphore~https://jobs.lever.co/uniphore/
+Clearco~https://clearco.breezy.hr/
+DICK'S Sporting Goods~https://www.linkedin.com/company/dick%27s-sporting-goods/jobs/
+Formlabs~https://careers.formlabs.com/asia/
+JLL~https://www.linkedin.com/company/jll/jobs/
+Preply~https://www.linkedin.com/company/preply/jobs/
+Cognitive3D~https://www.linkedin.com/jobs/engineer-jobs?trk=organization_guest-browse_jobs
+Archer Integrated Risk Management~https://recruiting.ultipro.com/RSA1000RSAS/JobBoard/d9232f43-e112-4585-a5de-af3dbf681e76
+Owner.com~https://jobs.lever.co/owner/
+CyberSmart~https://www.linkedin.com/company/be-cybersmart/jobs/
+Fundraise Up~https://boards.greenhouse.io/fundraiseup
+Ansys~https://www.linkedin.com/company/ansys-inc/jobs/
+Reibus~https://jobs.lever.co/reibus/
+OutboundEngine~https://www.outboundengine.com/careers
+Avanade~https://www.linkedin.com/company/avanade/jobs/
+3Play Media~https://www.3playmedia.com/company/jobs/
+Deltek~https://www.linkedin.com/company/deltek/jobs/
+Landstar~https://www.linkedin.com/company/landstar/jobs/
+Textio~https://www.linkedin.com/company/textio/jobs/
+Rover.com~https://jobs.lever.co/rover
+Vestwell~https://www.vestwell.com/careers
+Insperity~https://www.linkedin.com/company/insperity/jobs/
+Paynuity~https://jobs.lever.co/paynuity/
+Bynder~https://careers.bynder.com/
+ZipRecruiter~https://www.ziprecruiter.com/Search-Jobs-Near-Me
+Perforce Software~https://www.linkedin.com/company/perforce/jobs/
+Nuts.com~https://nuts.com/careers
+SUSE~https://www.linkedin.com/company/suse/jobs/
+Rebuilt~https://www.linkedin.com/company/rebuilt-investments/jobs/
+ANSER~https://anser.org/careers/opportunity/
+PerformLine~https://www.linkedin.com/company/performline-inc/jobs/
+Crowe~https://www.linkedin.com/company/crowe/jobs/
+CGI~https://www.linkedin.com/company/cgi/jobs/
+CONTROLTEK~https://controltekusa.com/careers
+Novidea~https://novidea.com/careers/
+Orb~http://withorb.com/careers
+Zerocater~https://zerocater.com/about/careers/
+Pacific Northwest National Laboratory~https://www.linkedin.com/company/pacific-northwest-national-laboratory/jobs/
+Sunhero~https://jobs.lever.co/sunhero/
+Rootstock Software~https://rootstock-software.breezy.hr
+Modern Energy~https://jobs.lever.co/modern
+Swoon~https://swoonstaffing.com/jobs/
+Workato~https://boards.greenhouse.io/workato
+Render~https://render.com/careers
+Flare~https://www.comeet.com/jobs/flare/36.00F
+Storfund~https://storfund.com/careers/
+Webflow~https://www.linkedin.com/company/webflow-inc-/jobs/
+Plooto~https://jobs.lever.co/Plooto
+United Imaging Healthcare~https://www.linkedin.com/company/united-imaging-healthcare/jobs/
+F5~https://www.linkedin.com/company/f5/jobs/
+Connatix~https://connatix.com/careers
+Upland Software~https://jobs.jobvite.com/upland-software
+Aircall~https://jobs.lever.co/aircall
+Siemens~https://www.linkedin.com/company/siemens/jobs/
+Bothrs~https://www.bothrs.com/careers
+EasyPost~https://jobs.lever.co/easypost-2
+LinkedIn~https://www.linkedin.com/jobs?trk=homepage-basic_directory_jobsHomeUrl
+Infor~https://www.linkedin.com/company/infor/jobs/
+Nodes & Links~https://jobs.lever.co/nodeslinks
+Flexcar~https://careers.flexcar.com/
+Turing~https://www.linkedin.com/company/turingcom/jobs/
+Splunk~https://www.linkedin.com/company/splunk/jobs/
+TIAA~https://www.linkedin.com/company/tiaa/jobs/
+Digital Remedy~https://jobs.lever.co/digitalremedy/
+COOP by Ryder™~https://jobs.coop.com/
+The Patrick J. McGovern Foundation~https://www.linkedin.com/company/mcgovern-foundation/jobs/
+ProjectDiscovery.io~https://boards.greenhouse.io/projectdiscoveryinc
+Khan Academy~https://www.linkedin.com/company/khan-academy/jobs/
+Tekion Corp~https://www.linkedin.com/company/tekion/jobs/
+Placer.ai~https://www.placer.ai/company/we-are-hiring
+Cintas~https://www.linkedin.com/company/cintas/jobs/
+NinjaOne~https://www.ninjaone.com/careers/
+SEON Fraud Fighters~https://seon.io/careers/
+Lead Forensics~https://www.linkedin.com/company/lead-forensics/jobs/
+Odoo~https://www.odoo.com/jobs
+Jobber~https://boards.greenhouse.io/jobber/
+Everytable~https://www.linkedin.com/company/everytable/jobs/
+Nutanix~https://jobs.jobvite.com/nutanix
+SPS Commerce~https://www.linkedin.com/company/sps-commerce/jobs/
+Absolute Software~https://jobs.jobvite.com/absolute
+Easygenerator~https://www.linkedin.com/company/easygenerator/jobs/
+Basis Technologies~https://www.linkedin.com/company/basis-technologies/jobs/
+Precisely~https://www.linkedin.com/company/preciselydata/jobs/
+THRILLWORKS~https://jobs.lever.co/thrillworks
+SpaceX~https://www.spacex.com/careers/jobs/
+Jackpocket~https://www.linkedin.com/company/jackpocket/jobs/
+Glide~https://www.glideapps.com/jobs
+ApplicantPro~https://www.applicantpro.com/openings/iapplicants/jobs
+Blue Yonder~https://careers.blueyonder.com/
+CubeLogic~https://cubelogic.com/careers/
+Stackline~https://boards.greenhouse.io/stackline
+Corestream~https://recruitingbypaycor.com/career/CareerHome.action?clientId=8a7883c6894c4dc90189694bd55509d1
+Bitly~https://bitly.com/pages/careers
+NeuraFlash~https://www.neuraflash.com/join-our-team/jobs
+Ahern~https://www.linkedin.com/company/j--f--ahern-co-/jobs/
+Awardco~https://www.linkedin.com/company/awardco/jobs/
+CaliberMind~https://calibermind.com/about/careers/
+Avidbots Corp.~https://avidbots.bamboohr.com/careers
+Glia~https://www.glia.com/jobs
+AuditBoard~https://www.auditboard.com/careers/jobs/
+Fortify~https://3dfortify.com/careers-list/
+Tailscale~https://tailscale.com/careers/
+Paylocity~https://www.linkedin.com/company/paylocity/jobs/
+CarGurus~https://careers.cargurus.com/job-search-results/
+interface.ai~https://www.linkedin.com/company/interface-ai/jobs/
+Intercom~https://www.intercom.com/careers?on_pageview_event=careers_footer
+Docebo~https://jobs.lever.co/docebo/
+Epos Now~https://www.eposnow.com/us/careers/open-positions/
+WP Engine~https://www.linkedin.com/company/wpengine/jobs/
+Nirvana Insurance~https://www.linkedin.com/company/nirvana-tech/jobs/
+Agiloft~https://jobs.lever.co/agiloft/
+Parsyl~https://www.parsyl.com/about#team
+Axe Staffing & Recruiting~https://axestaffingrecruiting.recruitee.com
+Addison Group~https://www.linkedin.com/company/addisongroup/jobs/
+Vanta~https://jobs.ashbyhq.com/vanta
+Drata~https://drata.com/careers
+Ampla~https://boards.greenhouse.io/ampla
+A.P. Moller - Maersk~https://www.linkedin.com/company/maersk-group/jobs/
+Stayntouch~https://www.stayntouch.com/careers/
+SaaScend~https://www.linkedin.com/company/saascend/jobs/
+Michelin~https://www.linkedin.com/company/michelin/jobs/
+Scratch Financial~https://jobs.lever.co/scratchfinancial/
+Thoughtful AI~https://www.thoughtful.ai/careers
+Thirty Capital~https://www.thirtycapital.com/careers/
+Forecast~https://forecasthq.bamboohr.com/careers
+Workable~https://www.linkedin.com/company/workable-hr/jobs/
+GitKraken~https://www.gitkraken.com/careers
+LegitScript~https://www.legitscript.com/about/careers/
+FundApps~https://jobs.lever.co/fundapps/
+Sharebite~https://sharebite.com/careers
+Momentum~https://jobs.lever.co/givemomentum
+CommerceIQ~https://boards.greenhouse.io/commerceiq
+Swan~https://www.welcometothejungle.com/en/companies/swan/jobs
+MyFitnessPal~https://boards.greenhouse.io/myfitnesspal/
+MUI~https://jobs.ashbyhq.com/mui/
+Fandom~https://about.fandom.com/careers
+HSTK (Haystack)~https://hstk.breezy.hr
+Trust Machines~https://trustmachines.co/careers/
+ISC2~https://www.linkedin.com/company/isc2/jobs/
+Veryfi~https://www.linkedin.com/company/veryfi-inc/jobs/
+ŌURA~https://www.linkedin.com/company/oura/jobs/
+AgentSync~https://agentsync.io/careers
+Revivn~https://jobs.lever.co/revivn.com
+Match2one - part of Verve Group~https://www.match2one.com/careers/
+Fidelity Investments~https://www.linkedin.com/company/fidelity-investments/jobs/
+Trapp Technology~https://trapptechnology.com/careers/careers-portal/
+Booking.com~https://www.linkedin.com/company/booking.com/jobs/
+ECS~https://www.linkedin.com/company/ecstechhq/jobs/
+Virtuozzo~https://virtuozzo.bamboohr.com/careers
+Helium SEO~https://heliumseo.applytojob.com
+Canary Technologies~https://jobs.lever.co/canarytechnologies/
+Shopmonkey~https://www.shopmonkey.io/careers
+Next Level Solutions~https://www.nlsnow.com/careers/join-us?hsLang=en
+SpryPoint~https://www.sprypoint.com/pages/careers/why-sprypoint/
+SOCi, Inc.~https://www.meetsoci.com/about/careers/
+Fast Enterprises, LLC~https://www.linkedin.com/company/fast-enterprises/jobs/
+The New York Times~https://www.linkedin.com/company/the-new-york-times/jobs/
+Imply~https://imply.io/positions
+Community Brands~https://www.linkedin.com/company/communitybrands/jobs/
+Traba~https://www.linkedin.com/company/traba-work/jobs/
+Figure~https://boards.greenhouse.io/figure
+Venn Technology~https://www.linkedin.com/company/venn-technology/jobs/
+TALSMART~https://www.talsmart.com/jobs
+LinearB~https://jobs.lever.co/LinearB
+Flowcode~https://boards.greenhouse.io/flowcode
+OpsLevel~https://jobs.lever.co/opslevel/
+Precoa~https://careers.precoa.com/search/jobs
+SiriusXM~https://www.linkedin.com/company/siriusxm/jobs/
+AbbVie~https://www.linkedin.com/company/abbvie/jobs/
+Tomorrow.io~https://www.tomorrow.io/careers/
+TicketNetwork~https://www.linkedin.com/company/ticketnetwork/jobs/
+Amplitude~https://boards.greenhouse.io/amplitude/
+Loft Orbital~https://jobs.lever.co/loftorbital
+CDW~https://www.linkedin.com/company/cdw/jobs/
+Convertr~https://www.convertr.io/careers
+Sunrun~https://www.linkedin.com/company/sunrun/jobs/
+BILL~https://www.bill.com/about-us/jobs
+Athelas~https://www.linkedin.com/company/athelas/jobs/
+Coperion~https://www.linkedin.com/company/coperion/jobs/
+InMarket~https://www.linkedin.com/company/inmarket_1/jobs/
+Axios~https://www.linkedin.com/company/axios-media/jobs/
+Guesty~https://www.guesty.com/careers/
+percipient.ai~https://jobs.lever.co/percipient
+Aurora Solar~https://jobs.ashbyhq.com/aurorasolar
+GroupA~https://www.linkedin.com/company/groupa/jobs/
+ADvendio~https://www.linkedin.com/jobs/search/?f_C=1544606&geoId=92000000&keywords=advendio&location=Worldwide
+Rapid7~https://careers.rapid7.com/jobs/search
+Merge~https://www.merge.dev/careers
+Jobvite~https://careers.employinc.com/
+Kiteworks~https://kiteworks.bamboohr.com/jobs
+TCP Software~https://www.tcpsoftware.com/careers
+ElevationHR, LLC~https://elevationhr.com/career/
+Narmi~https://jobs.lever.co/narmi/
+Orum~https://www.orum.com/careers
+Cube~https://jobs.ashbyhq.com/cubesoftware
+Justworks~https://boards.greenhouse.io/justworks
+D2L~https://www.linkedin.com/company/d2l/jobs/
+Immutable~https://jobs.lever.co/immutable/
+Tech Talent & Strategy~https://www.linkedin.com/company/tech-talent-and-strategy/jobs/
+Enel X~https://jobs.enel.com/it_IT/careers/JobOpeningsCustomer
+Bestpass~https://bestpass.com/about-us/careers
+Waterplan (YC S21)~https://jobs.ashbyhq.com/Waterplan
+Riot Games~https://www.linkedin.com/company/riot-games/jobs/
+Paycor~https://www.linkedin.com/company/paycor/jobs/
+PDQ~https://jobs.lever.co/PDQ
+Lightspeed Commerce~https://www.lightspeedhq.com/careers/openings/
+Form3~https://www.form3.tech/careers
+Yahoo~https://www.linkedin.com/company/yahoo/jobs/
+Aeonsemi~https://aeonsemi.com/jobs?locale=en
+Upside~https://www.linkedin.com/company/upside/jobs/
+Chef Robotics~https://jobs.lever.co/ChefRobotics
+Emburse~https://jobs.lever.co/emburse
+New Relic~https://www.linkedin.com/company/new-relic-inc-/jobs/
+ThousandEyes (part of Cisco)~https://www.thousandeyes.com/careers/
+Ascent Cloud~https://ascentcloud.io/careers/
+Wanderu~https://wanderu.breezy.hr/
+SentinelOne~https://www.linkedin.com/company/sentinelone/jobs/
+Redis~https://www.linkedin.com/company/redisinc/jobs/
+Bright Machines~https://jobs.lever.co/brightmachines/
+Integral.~https://apply.workable.com/integral-2
+Motorola Solutions~https://www.linkedin.com/company/motorolasolutions/jobs/
+Lenovo~https://jobs.lenovo.com/careers/SearchJobs/?jobRecordsPerPage=10&
+Activision~https://www.linkedin.com/company/activision/jobs/
+Tailored Brands, Inc.~https://www.linkedin.com/company/tailored-brands-inc-/jobs/
+NuvoAir~https://www.linkedin.com/company/nuvoair/jobs/
+Avantor~https://www.linkedin.com/company/avantorinc/jobs/
+The French Agency Professional Placement~https://frenchagency.biz/jobs/
+AudioEye~https://boards.greenhouse.io/audioeye/
+Premier Technology Advisors~https://www.procureit.com/careers
+Technical Toolboxes~https://technicaltoolboxes.com/careers/
+Softdocs~https://www.softdocs.com/company/careers
+Moveworks~https://www.moveworks.com/careers
+BEMO~https://bemo.rippling-ats.com
+ConstructConnect~https://careers-constructconnect.icims.com/jobs/search?hashed=-625918455&mobile=false&width=1140&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240
+SafeLease~https://jobs.lever.co/SafeLease
+AHEAD~https://jobs.lever.co/thinkahead
+Cadwell~https://recruitingbypaycor.com/career/CareerHome.action?clientId=8a7883c683620a4f018365990ad10010
+Alma~https://boards.greenhouse.io/alma/
+PM Group~https://www.linkedin.com/company/pm-group_165501/jobs/
+Storyblok~https://www.storyblok.com/jobs
+STIGroup~https://careers.hireology.com/stig
+Ossium Health~https://ossiumhealth.com/careers
+Adobe~https://www.linkedin.com/company/adobe/jobs/
+Text~https://jobs.lever.co/livechatinc
+LeanIX~https://www.linkedin.com/company/leanix/jobs/
+Itron, Inc.~https://www.linkedin.com/company/itroninc/jobs/
+ReversingLabs~https://www.reversinglabs.com/company/careers
+Salem Media Group~https://www.linkedin.com/company/salemmediagroup/jobs/
+Chewy~https://www.linkedin.com/company/chewy-com/jobs/
+Tray.io~https://boards.greenhouse.io/trayio/
+Metabase~https://jobs.lever.co/metabase/
+ShipBob~https://boards.greenhouse.io/shipbobinc/
+HealthJoy~https://www.healthjoy.com/careers
+1Password~https://jobs.lever.co/1password/
+Leapsome~https://jobs.ashbyhq.com/leapsome/
+Scratchpad~https://www.scratchpad.com/careers
+Makersite~https://makersitegmbh.recruitee.com
+Birdie~https://www.birdie.care/join-us
+Semrush~https://www.linkedin.com/company/semrush/jobs/
+Incode Technologies~https://incode.com/careers/open-positions/
+Open Systems~https://www.linkedin.com/company/opensystems/jobs/
+Apptegy~https://jobs.lever.co/apptegy
+Planet DDS~https://planetdds.applytojob.com
+ClickTime~https://jobs.lever.co/clicktime/
+Visier Inc.~https://boards.greenhouse.io/visiersolutionsinc
+Moloco~https://boards.greenhouse.io/moloco/
+Triblio (a Foundry company)~https://tribliocareers-idg.icims.com/jobs/search?ss=1
+Criteo~https://www.linkedin.com/company/criteo/jobs/
+Box~https://www.linkedin.com/company/box/jobs/
+Torc Robotics~https://torc.ai/job-board/
+IP Fabric~https://ipfabric.io/jobs-listing/
+Talend~https://talend.teamtailor.com/
+Top Hat~https://jobs.lever.co/tophat
+Yext~https://www.linkedin.com/company/yext/jobs/
+Pivotal~https://jobs.lever.co/pivotal
+Visma Creditro A/S~https://creditro.com/careers
+GROPYUS~https://www.linkedin.com/company/gropyus/jobs/
+BigPanda~https://www.linkedin.com/company/bigpanda/jobs/
+Descript~https://www.descript.com/careers
+Addigy~https://addigy.bamboohr.com/careers
+Dotdash Meredith~https://www.linkedin.com/company/dotdashmeredith/jobs/
+Matterport~https://jobs.lever.co/matterport/
+Keeper.app~https://jobs.ashbyhq.com/keeper
+MarketStar Bulgaria~https://wasatchproperty.wd1.myworkdayjobs.com/MarketStarCareers
+Logikcull | a reveal technology~https://jobs.lever.co/logikcull/
+CVS Health~https://www.linkedin.com/company/cvshealth/jobs/
+Bookipi~https://bookipi.com/job-openings/
+KEYENCE CORPORATION~https://www.linkedin.com/company/keyence/jobs/
+Adverity~https://www.adverity.com/careers
+Protiviti~https://www.linkedin.com/company/protiviti/jobs/
+Hyperproof~https://hyperproof.io/working-at-hyperproof/
+Conduktor~https://angel.co/company/conduktor
+Agilyx~https://agilyx.com/careers/
+Smartcar~https://jobs.lever.co/smartcar/
+Propel, Inc~https://www.linkedin.com/company/propel-inc/jobs/
+Clockwork~https://www.clockwork.com/careers/
+iCapital~https://boards.greenhouse.io/icapitalnetwork
+Lev~https://www.levdigital.com/join-the-team
+Blizzard Entertainment~https://www.linkedin.com/company/blizzard-entertainment/jobs/
+Picovoice~https://picovoice.ai/careers/
+InfluxData~https://www.influxdata.com/careers/
+POLITICO~https://recruiting.ultipro.com/PER1013PCLL/JobBoard/b972ff6a-41b7-4e97-9c71-273c2595c77d
+Circle~https://www.linkedin.com/company/circle-internet-financial/jobs/
+Path~https://jobs.ashbyhq.com/pathmentalhealth
+Coherent~https://coherent.bamboohr.com/jobs
+Tide~https://www.tide.co/careers/
+Dynatrace~https://www.linkedin.com/company/dynatrace/jobs/
+TechInsights~https://techinsights.applytojob.com
+Systech International~https://careers.dovercorporation.com/search/?createNewAlert=false&q=systech&locationsearch=&optionsFacetsDD_department=&optionsFacetsDD_facility=
+AlphaSense~https://boards.greenhouse.io/alphasense/
+Clubhouse~https://jobs.lever.co/clubhouse/
+ICIS~https://relx.wd3.myworkdayjobs.com/RiskSolutions
+Rose Rocket~https://jobs.ashbyhq.com/rose%20rocket
+Lithic~https://www.lithic.com/careers
+Trakstar, part of Mitratech~https://mitratech.com/about-us/careers/
+Mindtickle~https://jobs.lever.co/mindtickle/
+Coupa Software~https://www.linkedin.com/company/coupa-software/jobs/
+EDB~https://www.enterprisedb.com/careers/job-openings
+Litmos~https://www.litmos.com/company/careers
+Marco Technologies~https://jobs.lever.co/marco
+RevenueCat~https://www.revenuecat.com/careers/
+Vation Ventures~https://www.vationventures.com/careers
+Passport~https://www.linkedin.com/company/passportshipping/jobs/
+Billd~https://billd.com/careers/
+Retool~https://retool.com/careers/
+Flipp~https://corp.flipp.com/job-openings/
+Allovue~https://www.allovue.com/careers
+ZoomInfo~https://www.zoominfo.com/careers
+BetterUp~https://www.linkedin.com/company/betterup/jobs/
+CE Broker~https://cebroker.com/careers
+DataSnipper~http://careers.datasnipper.com/
+Momence~https://www.linkedin.com/company/themomence/jobs/
+One Click LCA~https://www.linkedin.com/company/one-click-lca/jobs/
+Teamwork.com~https://www.linkedin.com/company/teamwork-com/jobs/
+Workiva~https://www.linkedin.com/company/workiva/jobs/
+X-Team~https://x-team.com/remote-programming-jobs/
+Aurora~https://aurora.tech/careers
+N-able~https://www.linkedin.com/company/n-able/jobs/
+ChannelEngine~https://jobs.channelengine.com/
+Hillenbrand~https://www.linkedin.com/company/hillenbrand-inc/jobs/
+project44~https://boards.greenhouse.io/project44
+PandaDoc~https://www.pandadoc.com/careers/
+Avicado Construction Technology Services, LLC~https://www.avicado.com/about/careers/
+HelloFresh~https://www.linkedin.com/company/hellofresh/jobs/
+Novel Capital~https://apply.workable.com/novel-capital
+Kaleyra~https://kaleyra.teamtailor.com/
+Chameleon~https://www.chameleon.io/jobs
+JLL Technologies~https://www.linkedin.com/company/jlltechnologies/jobs/
+ShareFile~https://careers.cloud.com/jobs/search/sharefile
+AMAROK Security~https://amarok.com/careers/
+Canva~https://jobs.lever.co/canva/
+Perficient~https://www.linkedin.com/company/perficient/jobs/
+Docker, Inc~https://www.docker.com/career-openings/
+Cognota~https://cognota.com/careers/
+Eleos Health~https://www.linkedin.com/company/eleoshealth/jobs/
+Lydonia Technologies~https://lydoniatech.com/career/
+Factbird~https://www.linkedin.com/company/factbird-aps/jobs/
+PayIt~https://payitgov.com/careers/
+MetaLab~https://boards.greenhouse.io/metalab/
+Resource Innovations~https://www.linkedin.com/company/resourceinnovations/jobs/
+Zopa Bank~https://jobs.lever.co/zopa/
+Visit.org~https://visit-talent.freshteam.com/jobs
+Demand Chain~https://www.demandchain.com/careers/
+IntelyCare~https://www.linkedin.com/company/intelycare/jobs/
+Mediafly~https://jobs.lever.co/Mediafly
+data.world~https://data.world/company/careers/
+Intapp~https://www.linkedin.com/company/intapp/jobs/
+NewtonX~https://www.newtonx.com/careers/
+Lenus~https://www.lenusehealth.com/careers
+Zenni Optical~https://www.linkedin.com/company/zenni-optical/jobs/
+TaxBit~https://boards.greenhouse.io/taxbit
+PayNearMe~https://www.linkedin.com/company/paynearme/jobs/
+Elephant Energy~https://elephantenergy.com/elephant-careers/
+John Deere~https://www.linkedin.com/company/john-deere/jobs/
+Dashlane~https://dashlane.teamtailor.com/
+One Medical~https://www.onemedical.com/careers/all-departments/
+UiPath~https://www.linkedin.com/company/uipath/jobs/
+Funnel~https://jobs.funnel.io/
+Equi~https://jobs.ashbyhq.com/equi/
+Pleo~https://www.pleo.io/en/careers/jobs
+A.Team~https://www.notion.so/ateams/Careers-at-A-Team-4a4af87f3a3b4246bf63d8c1c9201320
+SettleMint~https://www.linkedin.com/company/settlemint/jobs/
+Candid Health~https://www.linkedin.com/company/candid-health/jobs/
+Hiya Inc.~https://www.hiya.com/careers
+kimkim~https://www.kimkim.com/careers
+Certn~https://certn.co/careers/
+Immersive Labs~https://careers.immersivelabs.com/jobs/
+Yardi~https://careers.yardi.com/openings/
+ButterflyMX®~https://www.linkedin.com/company/butterflymx/jobs/
+Schell Games~https://schellgames.com/careers
+Prezi~https://prezi.com/jobs/
+Kaseya~https://www.linkedin.com/company/kaseya/jobs/
+MOSTLY AI~https://mostly.ai/jobs
+Zocdoc~https://www.zocdoc.com/about/careers-list/
+Imprivata~https://jobs.jobvite.com/imprivata
+impact.com~https://www.linkedin.com/company/impactdotcom/jobs/
+Uplight~https://jobs.jobvite.com/uplight/jobs
+Workpath~https://www.linkedin.com/company/workpathhq/jobs/
+Kojo~https://www.usekojo.com/careers
+Sincere Corporation~https://www.sincere.com/careers
+Sequel.io~https://www.linkedin.com/company/sequelio/jobs/
+AIM Consulting Group~https://aimconsulting.com/careers
+Eco~https://www.linkedin.com/company/eco-pay/jobs/
+CHEQ~https://cheq.ai/careers/
+Buildertrend~https://buildertrend.com/careers/
+DemandLab~https://www.linkedin.com/company/demandlab/jobs/
+iSpot.tv~https://www.ispot.tv/about/careers/listings
+Collective[i]~https://jobs.lever.co/collectivei/
+FutureFit AI~https://jobs.ashbyhq.com/futurefitai/
+Houzz~https://www.linkedin.com/company/houzz/jobs/
+Super Dispatch~https://superdispatch.breezy.hr/
+Emarsys~https://jobs.emarsys.com/
+Equinix~https://www.linkedin.com/company/equinix/jobs/
+FORM~https://jobs.lever.co/form
+AppFolio, Inc.~https://www.appfolio.com/open-roles
+Lusha~https://www.lusha.com/careers/
+DuckDuckGo~https://duckduckgo.recruitee.com
+Notable~https://jobs.ashbyhq.com/notable/
+FICO~https://www.linkedin.com/company/fico/jobs/
+O'Reilly~https://www.linkedin.com/company/oreilly/jobs/
+Worksighted~https://boards.greenhouse.io/worksighted/
+Umbra~https://umbralab.bamboohr.com/jobs
+Uber Freight~https://www.linkedin.com/company/uber-freight/jobs/
+SmithRx~https://smithrx.com/careers/
+Forward~https://jobs.lever.co/goforward
+PerkSpot~https://perkspot12.applytojob.com
+Stampli~https://stampli.com/careers
+SpotOn~https://www.spoton.com/careers/
+LogicGate~https://boards.greenhouse.io/logicgate/
+QuillHash Group~https://www.quillhash.com/careers
+VertiGIS~https://vertigis.recruitee.com/
+Lunio~https://lunio.ai/about-us/careers/
+First Republic~https://careers.firstrepublic.com/
+LeadIQ~https://jobs.ashbyhq.com/leadiq/
+Younite-AI~https://younite-ai.com/careers
+Zuva~https://zuva.ai/careers/
+Rewiring America~https://apply.workable.com/rewiring-america
+QA Consultants~https://qaconsultants.com/careers/
+Adyen~https://www.linkedin.com/company/adyen/jobs/
+Flare~https://flare.io/company/careers/
+Aclima, Inc.~https://www.aclima.io/careers
+Moody's Analytics~https://www.linkedin.com/company/moodysanalytics/jobs/
+Ontra~https://www.ontra.ai/careers/
+Property Meld~https://property-meld.breezy.hr
+Rye~https://www.linkedin.com/company/rye/jobs/
+#paid~https://www.linkedin.com/company/hashtagpaid/jobs/
+Figures~https://www.linkedin.com/company/f1gures/jobs/
+Wrike~https://www.linkedin.com/company/wrike/jobs/
+Nextdoor~https://www.linkedin.com/company/nextdoor-com/jobs/
+Cvent~https://www.linkedin.com/company/cvent/jobs/
+Wavestone~https://www.linkedin.com/company/wavestone/jobs/
+Xero~https://jobs.lever.co/xero/
+Customer.io~https://customer.io/careers
+Neo Financial~https://www.linkedin.com/company/neo-financial/jobs/
+Cato Networks~https://www.linkedin.com/company/cato-networks/jobs/
+Axon~https://boards.greenhouse.io/axon/
+Torus~https://www.linkedin.com/company/torusrev/jobs/
+Bazaarvoice~https://jobs.lever.co/bazaarvoice/
+Aquatic Capital Management~https://boards.greenhouse.io/aquaticcapitalmanagement/
+Tapcart~https://www.tapcart.com/careers
+Respondent~https://jobs.lever.co/respondent/
+Degreed~https://boards.greenhouse.io/degreed
+Zencore~https://jobs.lever.co/zencore/
+Front~https://jobs.lever.co/frontapp
+Cribl~https://cribl.io/jobs
+Reddit, Inc.~https://www.redditinc.com/careers
+Thankful~https://www.gladly.com/careers/
+Workday~https://www.linkedin.com/company/workday/jobs/
+Vidyard~https://www.vidyard.com/careers/
+Red River~https://www.linkedin.com/company/red-river-technology/jobs/
+OTA Insight~https://careers.otainsight.com/
+ServiceNow~https://www.linkedin.com/company/servicenow/jobs/
+Sprinklr~https://www.linkedin.com/company/sprinklr/jobs/
+Mimecast~https://careers.mimecast.com/en/jobs/
+Zeta Global~https://zetaglobal.com/about/life-at-zeta/
+Union.ai~https://union.ai/careers
+Monte Carlo~https://jobs.ashbyhq.com/montecarlodata
+Genies~https://boards.greenhouse.io/genies/
+Paxos~https://paxos.com/careers/
+GoodRx~https://www.linkedin.com/company/goodrx/jobs/
+Sauce Labs~https://saucelabs.com/company/careers
+Provenir~https://www.provenir.com/careers/
+SoFi~https://www.linkedin.com/company/sofi/jobs/
+Optiply~https://optiply.com/nl/vacatures/
+Warriors Recruiting~https://jobs.crelate.com/portal/warriorsrecruiting
+Audicus~https://boards.greenhouse.io/audicus
+Certain Affinity~https://www.linkedin.com/company/certain-affinity/jobs/
+Lumos~https://www.lumos.com/careers
+Vajro~https://www.vajro.com/careers
+Linus Health~https://linushealth.com/careers
+ngrok~https://boards.greenhouse.io/ngrokinc
+Iterable~https://iterable.com/careers/
+Saleo~https://www.linkedin.com/company/saleo-sales-demo-experience/jobs/
+Dialpad~https://www.linkedin.com/company/dialpad/jobs/
+Coolset~https://www.linkedin.com/company/coolset/jobs/
+brightwheel~https://jobs.lever.co/brightwheel/
+Silverfort~https://www.linkedin.com/company/silverfort/jobs/
+Hopebridge~https://www.linkedin.com/company/hopebridge-autism-therapy-centers/jobs/
+Multilingual Jobs Worldwide~https://www.multilingualjobsworldwide.com/jobs
+TestBox~https://www.testbox.com/career
+Plative~https://www.linkedin.com/company/plative/jobs/
+PSD Citywide~https://psdcitywide.com/about/careers/
+Gecko Robotics, Inc.~https://www.linkedin.com/company/gecko-robotics-llc/jobs/
+Reaktor~https://www.reaktor.com/careers
+Baton~https://boards.greenhouse.io/baton
+Lightrun~https://lightrun.com/careers/
+eBay~https://www.linkedin.com/company/ebay/jobs/
+Antithesis~https://antithesis.breezy.hr/
+Block~https://block.xyz/careers
+H1~https://jobs.lever.co/h1/
+Acceleration Partners~https://boards.greenhouse.io/accelerationpartners/
+Aktion Associates, Inc.~https://www.aktion.com/company/careers/
+JFrog~https://www.linkedin.com/company/jfrog-ltd/jobs/
+Deloitte~https://www.linkedin.com/company/deloitte/jobs/
+Provi~https://www.linkedin.com/company/provihq/jobs/
+CyberCube~https://jobs.lever.co/cybcube
+Hightouch~https://hightouch.com/careers
+IBM~https://www.linkedin.com/company/ibm/jobs/
+Promenade Group~https://www.linkedin.com/company/promenade-co/jobs/
+Built Technologies~https://boards.greenhouse.io/getbuilt
+Tipalti~https://www.linkedin.com/company/tipalti/jobs/
+Alianza, Inc.~https://www.linkedin.com/company/alianza/jobs/
+Trader Interactive~https://www.traderinteractive.com/careers/
+StrongMind~https://recruiting2.ultipro.com/STR1017SMINC/JobBoard/e883a137-8797-484c-bf4d-c3d514ec5e38
+ResQ~https://www.linkedin.com/company/getresq-restaurant-repair/jobs/
+PolyAI~https://poly.ai/company/careers/
+Capital One~https://www.linkedin.com/company/capital-one/jobs/
+Sodexo~https://www.linkedin.com/company/sodexo/jobs/
+Six & Flow~https://www.sixandflow.com/careers/lead-strategist
+Aisera~https://boards.greenhouse.io/aiserajobs
+Swirlds Labs~https://swirldslabs.com/careers
+DoubleVerify~https://doubleverify.com/careers/current-openings/
+Pax8~https://www.pax8.com/en-us/careers/
+Chainalysis~https://www.chainalysis.com/careers/job-openings/
+Northbeam~https://boards.greenhouse.io/northbeam
+Ad Hoc LLC~https://adhoc.team/join/jobs/
+PingCAP~https://jobs.lever.co/pingcap/
+Mavrck~https://www.mavrck.co/careers/
+Lyra Health~https://jobs.lever.co/lyrahealth/
+Cepton~https://jobs.lever.co/cepton/
+T-Mobile~https://www.linkedin.com/company/t-mobile/jobs/
+Apex.AI~https://jobs.lever.co/apex-ai?
+YCharts~https://recruiting.paylocity.com/recruiting/jobs/All/78419728-0f20-46ce-8f93-12ae28d00481/YCHARTS-INC
+MedBridge~https://recruiting.paylocity.com/recruiting/jobs/All/235886f5-63d7-4b56-883a-0fbad71bff8b/MedBridge-Inc
+Varonis~https://www.linkedin.com/company/varonis/jobs/
+DataGrail~https://www.datagrail.io/careers/
+Intranet Connections~https://intranetconnections.applytojob.com
+Coveo~https://www.coveo.com/en/company/careers
+Datadog~https://www.linkedin.com/company/datadog/jobs/
+Roblox~https://www.linkedin.com/company/roblox/jobs/
+Elsevier~https://www.linkedin.com/company/elsevier/jobs/
+OneTrust~https://www.linkedin.com/company/onetrust/jobs/
+Cleary~https://gocleary.com/careers/
+BrightBid~https://brightbid.com/work-with-us/#lediga-jobb
+Uber~https://www.linkedin.com/company/uber-com/jobs/
+MAVAN~https://www.linkedin.com/company/mavan/jobs/
+Juniper Networks~https://careers.juniper.net/
+VELOX Media~https://www.veloxmedia.com/careers/
+Palantir Technologies~https://jobs.lever.co/palantir
+Vetted~https://jobs.lever.co/vetted/
+Granite Telecommunications~https://www.linkedin.com/company/granite-telecommunications/jobs/
+FloQast~https://jobs.lever.co/floqast/
+Procore Technologies~https://www.linkedin.com/company/procore-technologies/jobs/
+BMNT~https://boards.greenhouse.io/bmnt
+Mercedes-Benz Research & Development North America, Inc.~https://jobs.lever.co/MBRDNA
+SixFifty~https://www.sixfifty.com/about/careers/
+Green Irony~https://www.linkedin.com/company/green-irony/jobs/
+Tyson & Mendes~https://www.tysonmendes.com/careers/
+Pave~https://boards.greenhouse.io/paveakatroveinformationtechnologies
+Zylo~https://recruiting.paylocity.com/recruiting/jobs/All/f13aa047-0fd6-4ae1-95d3-058f4f531973/ZYLO-INC
+SmartBear~https://smartbear.com/company/careers/
+Kodiak~https://jobs.lever.co/kodiak
+CannDelta Inc. - Regulatory and Scientific Consulting Firm~https://canndelta.com/careers/
+BMC Software~https://jobs.bmc.com/Careers/SearchJobs
+Reverb~https://reverb.com/page/jobs
+LaunchDarkly~https://boards.greenhouse.io/launchdarkly/
+Zerto~https://www.zerto.com/company/careers/
+SEAM Group~https://www.linkedin.com/company/seamgroup/jobs/
+Peloton Interactive~https://www.linkedin.com/company/peloton-interactive-/jobs/
+Sprockets~https://sprockets.ai/careers/
+Lockheed Martin~https://www.linkedin.com/company/lockheed-martin/jobs/
+Monotype~https://www.linkedin.com/company/monotype/jobs/
+PartsTech~https://partstech.com/careers/
+Ncontracts~https://www.ncontracts.com/careers
+Benchling~https://www.linkedin.com/company/benchling/jobs/
+Mural~https://boards.greenhouse.io/mural/
+BambooHR~https://www.linkedin.com/company/bamboohr/jobs/
+incident.io~https://incident.io/careers
+Sonrai Security~https://www.linkedin.com/company/sonrai-security/jobs/
+Prolink~https://www.linkedin.com/company/prolinkworks/jobs/
+StreamSets Inc.~https://softwareag.wd3.myworkdayjobs.com/rec_sag_ext
+Cruise~https://www.linkedin.com/company/getcruise/jobs/
+GoodLeap~https://jobs.lever.co/goodleap
+Grips Intelligence~https://gripsintelligence.com/careers
+Dropbox~https://www.linkedin.com/company/dropbox/jobs/
+Creyos (formerly Cambridge Brain Sciences)~https://www.linkedin.com/company/creyos/jobs/
+insightsoftware~https://insightsoftware.com/careers/
+Starburst~https://jobs.lever.co/starburstdata
+Regal.io~https://jobs.lever.co/regalvoice
+Aspire~https://www.linkedin.com/company/aspireio/jobs/
+VETRO, Inc.~https://vetro-fibermap-inc.breezy.hr
+Infostrux Solutions~https://www.infostrux.com/careers
+Guild~https://www.linkedin.com/company/guildeducation/jobs/
+Confiant Inc~https://www.confiant.com/careers
+Hewlett Packard Enterprise~https://www.linkedin.com/company/hewlett-packard-enterprise/jobs/
+Vonage~https://boards.greenhouse.io/vonage/
+Verve Group~https://vervegroup.recruitee.com/
+Enverus~https://jobs.jobvite.com/drillinginfo
+Propeller~https://propelleraero.breezy.hr/
+Pica8, Inc.~https://www.pica8.com/company/careers/
+Kantox~https://www.kantox.com/en/careers/?
+stakefish~https://stake.fish/jobs
+RxVantage~https://www.linkedin.com/company/rxvantage/jobs/
+GuestReady~https://www.linkedin.com/company/guestready/jobs/
+Groove, a Clari Company~https://boards.greenhouse.io/embed/job_board?for=groove
+Tegus~https://jobs.lever.co/tegus
+NexHealth~https://www.nexhealth.com/careers/open-positions
+Abnormal Security~https://careers.abnormalsecurity.com/open-roles
+Upfort~https://boards.greenhouse.io/upfort
+WellnessLiving~https://jobs.gohire.io/wellnessliving-zvcrxvet/
+Podium~https://www.linkedin.com/company/podium/jobs/
+Neostella~https://www.neostella.com/careers/
+AnyRoad~https://jobs.lever.co/anyroad/
+Auvik~https://www.auvik.com/careers/
+Golioth~https://golioth.rippling-ats.com
+Bloomberg News~https://www.linkedin.com/company/bloomberg-news/jobs/
+PlayStation~https://boards.greenhouse.io/sonyinteractiveentertainmentglobal
+Moogsoft~https://jobs.lever.co/moogsoft
+Grant Thornton LLP (US)~https://www.linkedin.com/company/grant-thornton-llp/jobs/
+AVIOBOOK~https://www.linkedin.com/jobs/aviobook-jobs-worldwide?f_C=1003745&trk=top-card_top-card-primary-button-top-card-primary-cta&position=1&pageNum=0
+ApolloMed~https://www.linkedin.com/company/apollo-med/jobs/
+HubSpot~https://www.hubspot.com/careers/jobs?hubs_signup-cta=careers-nav-cta&hubs_content=www.hubspot.com%2F&hubs_content-cta=null
+JMP~https://jmp-sas.icims.com/jobs/search?ss=1&hashed=-435680032
+Grammarly~https://www.grammarly.com/jobs/openings
+Live Chair Health~https://www.linkedin.com/company/live-chair-health/jobs
+Custom Ink~https://www.linkedin.com/company/custom-ink/jobs/
+Airbase~https://boards.greenhouse.io/airbase
+Relay~https://boards.greenhouse.io/relaypro
+Omni Creator Products~https://www.ocp.gg/jobs
+OpenGov Inc.~https://jobs.lever.co/opengov
+Reach Progress PBC~https://www.reach.vote/jobs/
+Bloomreach~https://boards.greenhouse.io/bloomreach/
+Zyte~https://www.zyte.com/jobs/
+Qualified~https://jobs.lever.co/qualified
+Doran Jones Inc.~https://jobs.lever.co/doranjones
+Gorgias~https://www.gorgias.com/about-us/jobs
+Craft.co~https://enterprise.craft.co/careers
+SamCart~https://boards.greenhouse.io/samcarthiring
+Checkr, Inc.~https://checkr.com/company/careers/open-careers
+Optm~https://optm.com/company/careers#Open-Roles
+HoneyBook~https://www.honeybook.com/careers
+Codesmith~https://www.linkedin.com/company/codesmithdev/jobs
+DirectShifts~https://www.directshifts.com/careers
+Totango~https://totango.applytojob.com
+Social Factor~https://www.linkedin.com/company/social-factor/jobs/
+Burwood Group~https://careers.smartrecruiters.com/BurwoodGroupInc
+Boozt~https://careers.booztgroup.com/
+Cloudflare~https://www.cloudflare.com/careers/jobs/
+RevGenius~https://www.linkedin.com/company/revgenius/jobs/
+Virtuous~https://www.linkedin.com/company/virtuous/jobs/
+Hawk Ridge Systems~https://recruiting2.ultipro.com/HAW1006HARI/JobBoard/e2ed3d02-77ba-4ea8-b0b4-a59d2b7c6bb9/?q=&o=postedDateDesc&w=&wc=&we=&wpst=
+Intuition Machines~https://www.linkedin.com/company/intuition-machines-inc./jobs/
+FinancialForce~https://certinia.com/about/careers/
+SumUp~https://www.sumup.com/careers/positions/
+TriNet~https://www.linkedin.com/company/trinet/jobs/
+CharterUP~https://charterup.teamtailor.com/
+Matillion~https://jobs.lever.co/matillion/
+Plante Moran~https://www.linkedin.com/company/plante-moran/jobs/
+Signals~https://getsignals.ai/careers/
+Yelp~https://www.linkedin.com/company/yelp-com/jobs/
+Zapier~https://zapier.com/jobs/
+Narvar~https://corp.narvar.com/careers
+Logixboard~https://jobs.lever.co/logixboard
+ASCENDING Inc.~https://www.linkedin.com/company/ascendingllc/jobs/
+Grafana Labs~https://www.linkedin.com/company/grafana-labs/jobs/
+CodeHS~https://codehs.hire.trakstar.com/
+Restaurant365~https://jobs.lever.co/restaurant365/
+1-800Accountant~https://1800accountant.teamtailor.com/
+Visualping~https://www.linkedin.com/company/visualping/jobs/
+Alteryx~https://www.linkedin.com/company/alteryx/jobs/
+Bloomberg Industry Group~https://www.linkedin.com/company/bloomberg-industry-group/jobs/
+Xigent~https://xigentsolutions.com/company/careers/
+Maven Clinic~https://www.linkedin.com/company/mavenclinic/jobs/
+Blackcart~https://apply.workable.com/blackcart
+Avetta~https://www.avetta.com/company/careers/careers-list
+OneSignal~https://www.linkedin.com/company/onesignal/jobs/
+BECU~https://www.linkedin.com/company/becu/jobs/
+Handshake~https://joinhandshake.com/career-centers/
+Jeeng, an OpenWeb company~https://www.jeeng.com/careers/
+Thryv~https://recruiting2.ultipro.com/SUP1002SPRM
+Leadfeeder~https://www.leadfeeder.com/jobs/
+MPB~https://careers.mpb.com/
+Behavioral Health Group - BHG~https://info.bhgrecovery.com/open-positions
+Thunkable~https://jobs.lever.co/thunkable/
+Zip~https://www.linkedin.com/company/theziphq/jobs/
+athenahealth~https://www.linkedin.com/company/athenahealth/jobs/
+ZOLL Medical Corporation~https://www.linkedin.com/company/zoll-medical-corporation/jobs/
+CoinTracker~https://www.linkedin.com/company/cointracker/jobs/
+Build Staffing Group~https://buildstaffing.com/job-seekers
+Attain~https://boards.greenhouse.io/attain
+Recorded Future~https://boards.greenhouse.io/recordedfuture/
+Woflow~https://jobs.ashbyhq.com/woflow/
+Covariant~https://jobs.lever.co/covariant
+LMAX Group~https://careers.lmax.com/job-openings/
+Accenture~https://www.linkedin.com/company/accenture/jobs/
+ReadMe~https://jobs.ashbyhq.com/readme/
+At-Bay~https://www.linkedin.com/company/at-bay/jobs/
+Notion~https://www.notion.so/careers
+WillowTree~https://www.linkedin.com/company/willowtree/jobs/
+OnLogic~https://www.onlogic.com/company/careers/
+Bluevine~https://www.linkedin.com/company/bluevine/jobs/
+VRChat Inc.~https://jobs.lever.co/vrchat
+Confluent~https://careers.confluent.io/search/jobs
+Warby Parker~https://boards.greenhouse.io/warbyparker
+numa~https://numastays.com/en/careers
+Skyscanner~https://www.linkedin.com/company/skyscanner/jobs/
+Bonterra~https://bonterra.wd1.myworkdayjobs.com/bonterratech
+MRE Consulting~https://mre-consulting.com/careers/
+Corsha~https://www.linkedin.com/company/corsha/jobs/
+EngageSmart~https://engagesmart.com/careers-engagesmart/
+Rippling~https://www.rippling.com/careers/open-roles
+Clio - Cloud-Based Legal Technology~https://www.linkedin.com/company/clio---cloud-based-legal-technology/jobs/
+Palo Alto Networks~https://jobs.paloaltonetworks.com/en/jobs/
+Relay Network~https://www.linkedin.com/company/relay-network-llc/jobs/
+Extend~https://www.linkedin.com/company/paywithextend/jobs/
+Alegeus~https://www.linkedin.com/company/alegeus-technologies/jobs/
+Upraised~https://upraised.freshteam.com/jobs/
+CleanSlate Technology Group~https://www.cleanslatetg.com/who-we-are/careers/
+Seamless.AI~https://seamless.ai/company/careers
+Luminate~https://luminatedata.com/careers/
+Flying Cat Marketing~https://flyingcatmarketing.com/careers/
+Yokoy~https://jobs.eu.lever.co/yokoy
+Nordcloud, an IBM Company~https://nordcloud-career.breezy.hr
+Leapfin~https://www.leapfin.com/careers/
+Autodesk~https://www.linkedin.com/company/autodesk/jobs/
+Premise~https://www.premise.com/careers/
+MongoDB~https://www.linkedin.com/company/mongodbinc/jobs/
+Materialize~https://materialize.com/careers/
+ForgeRock~https://www.forgerock.com/about-us/careers
+Aumni~https://www.linkedin.com/company/aumni/jobs/
+Ascend Learning~https://recruiting.ultipro.com/ASC1003/JobBoard/57b0d3c6-a250-9a6a-7787-1093a619de01/?q=&o=postedDateDesc
+RLDatix~https://www.linkedin.com/company/rldatix/jobs/
+Samsara~https://samsara.com/company/careers/roles
+N1 Health~https://www.n1health.com/about/careers/
+Super.com~https://jobs.lever.co/super-com
+Celigo~https://www.linkedin.com/company/celigo-inc/jobs/
+Attentive~https://jobs.lever.co/attentive
+Synctera~https://synctera.com/careers
+Availity~https://www.linkedin.com/company/availity/jobs/
+Flexera~https://www.linkedin.com/company/flexera/jobs/
+Q4~https://jobs.lever.co/q4inc
+Mux~https://www.mux.com/jobs
+Superblocks~https://boards.greenhouse.io/superblocks/
+Axis Communications~https://www.linkedin.com/company/axis-communications/jobs/
+Losant~https://www.losant.com/careers
+Montoux~https://www.montoux.com/careers
+Egress Software Technologies~https://www.egress.com/careers/vacancies
+Parcel Perform~https://parcelperform.freshteam.com/jobs/
+Vertex Inc.~https://www.linkedin.com/company/vertex-inc./jobs/
+Genesys~https://www.linkedin.com/company/genesys/jobs/
+WorkOS~https://jobs.lever.co/workos/
+Mindex~https://www.mindex.com/jobs
+Spokeo~https://www.spokeo.com/careers/jobs
+Figma~https://boards.greenhouse.io/figma/
+Pair Eyewear~https://paireyewear.com/pages/careers
+Rangle.io~https://www.linkedin.com/company/rangle/jobs/
+Airwallex~https://www.linkedin.com/company/airwallex/jobs/
+Heroku~https://www.heroku.com/careers
+CybSafe~https://www.linkedin.com/company/cybsafe-limited/jobs/
+InvestNext~https://apply.workable.com/investnext
+Opentrons Labworks Inc.~https://opentrons.com/about/jobs/
+FareHarbor~https://fareharbor.com/jobs/all/
+the LEGO Group~https://www.linkedin.com/company/lego-group/jobs/
+Relevant Healthcare~https://relevant.healthcare/jobs
+Deel~https://jobs.ashbyhq.com/deel/
+Ceribell │ Point-of-Care EEG~https://ceribell.com/careers/
+Entegee~https://www.entegee.com/engineering-jobs/
+Loopio~https://jobs.lever.co/loopio/
+Anvil~https://www.useanvil.com/careers/
+TravelPerk~https://www.linkedin.com/company/travelperk/jobs/
+tvScientific~https://www.linkedin.com/company/tvscientific/jobs
+Day Zero Diagnostics, Inc~https://www.dayzerodiagnostics.com/about-us/careers/
+Findigs, Inc.~https://www.linkedin.com/company/findigs/jobs/
+Terzo~https://terzocloud.freshteam.com/jobs
+ClickUp~https://clickup.com/careers
+Huron~https://www.linkedin.com/company/huronconsulting/jobs/
+Papa~https://www.papa.com/about/careers
+Unit21~https://www.unit21.ai/company/careers
+Algolia~https://www.linkedin.com/company/algolia/jobs/
+Faraday~https://www.linkedin.com/company/faradayio/jobs/
+TeamWorx Security~https://www.teamworxsecurity.com/careers/
+OneUp Sales~https://oneup.app.wearecandidly.com/careers
+The Lacek Group~https://www.lacek.com/careers
+Snagajob~https://www.snagajob.com/career
+Formstack~https://jobs.lever.co/formstack/
+ZayZoon~https://www.zayzoon.com/work-with-us
+Propagate~https://www.linkedin.com/company/propagateag/jobs/
+GlobalLogic~https://www.linkedin.com/company/globallogic/jobs/
+JABU~https://jabu.breezy.hr/
+LogicMonitor~https://www.linkedin.com/company/logicmonitor/jobs/
+runZero~https://www.runzero.com/careers/
+Chapter~https://boards.greenhouse.io/chapter/
+Broadcom~https://www.linkedin.com/company/broadcom/jobs/
+Shawbrook Bank~https://careers.shawbrook.co.uk/opportunities/
+Databricks~https://www.databricks.com/company/careers/open-positions
+Motive~https://www.linkedin.com/company/motive-inc/jobs/
+Porch Group~https://porchgroup.com/careers
+Analog Devices~https://www.linkedin.com/company/analog-devices/jobs/
+Second Front Systems~https://jobs.lever.co/secondfrontsystems/
+Solv.~https://jobs.lever.co/solvhealth
+Semgrep~https://semgrep.dev/about/careers/
+Embrace~https://boards.greenhouse.io/embrace/
+CleanHub~https://www.linkedin.com/company/cleanhub/jobs/
+Pointer~https://jobs.pointerstrategy.com.au/
+connectRN~https://www.connectrn.com/careers
+Snowplow~https://jobs.lever.co/snowplow
+Slickdeals~https://slickdeals.net/corp/careers.html
+doxo~https://www.doxo.com/about/careers/
+Amla Commerce (Creator of Artifi and Znode)~https://www.amla.io/careers/
+nTop~https://boards.greenhouse.io/ntop
+Vena Solutions~https://www.lifeatvena.com/jobs
+ZeroFox~https://jobs.lever.co/zerofox
+FlutterFlow~https://www.ycombinator.com/companies/flutterflow/jobs
+EvenUp~https://www.evenuplaw.com/careers
+Varicent~https://www.varicent.com/cs/c/?cta_guid=094069ca-328e-4457-9392-e60b08e922d2&signature=AAH58kGH0GjZ1VuOEctuYmKUpgcmGEbvKQ&pageId=30755879350&placement_guid=ef2e75a2-f9ed-4f5c-86f8-1c1598a23f78&click=1432afd2-fcfc-487d-a3fe-302bf709052f&hsutk=ade1304308b54e0c37a3a91d2837ac78&canon=https%3A%2F%2Fwww.varicent.com%2Fcompany%2Fcareers&portal_id=6899630&redirect_url=APefjpEOsSFib4GHFRQFp_jG3RpCqSVCviILkt9BS1dy5RMTJgAdFnsoI-IHD6zptW2qYJ44rtqXWcaMwOPIijhEhZS82oQnlmLaAdG64Ddubj5BPbQj-v8&ts=1697577023453&__hstc=104425759.ade1304308b54e0c37a3a91d2837ac78.1697577024141.1697577024141.1697577024141.1&__hssc=104425759.1.1697577024143&__hsfp=2764680836&contentType=standard-page
+Auror~https://www.linkedin.com/company/auror/jobs/
+NICE~https://www.nice.com/careers/apply
+Vicinity Energy~https://www.vicinityenergy.us/careers
+ByteDance~https://www.linkedin.com/company/bytedance/jobs/
+BioRender~https://jobs.lever.co/biorender/
+HackerOne~https://jobs.ashbyhq.com/hackerone
+BOK Financial~https://www.linkedin.com/company/bok-financial/jobs/
+Constant Contact~https://boards.greenhouse.io/constantcontact
+Sayva Solutions~https://sayvasolutions.com/search-open-positions/
+Schoox~https://www.linkedin.com/company/schoox/jobs/
+EvolutionIQ~https://evolutioniq.com/careers/
+FX Innovation~https://www.fxinnovation.com/jobs/
+Marigold~https://www.linkedin.com/company/meet-marigold/jobs/
+Jamf~https://www.jamf.com/about/careers/jobs/
+Living Security~https://www.livingsecurity.com/careers-and-culture
+Calendly~https://careers.calendly.com/jobs/
+Allied Global Marketing~https://www.linkedin.com/company/allied-global-mkg/jobs/
+Akamai Technologies~https://akamaicareers.inflightcloud.com/search
+Archimedes~https://careers.archimedesfi.com/
+Gartner~https://jobs.gartner.com/search-jobs?_its=JTdCJTIydmlkJTIyJTNBJTIyNzE4YTdhY2MtYTcwZi00YjEwLTliNzItZmNmY2E3MjY4ODMwJTIyJTJDJTIyc3RhdGUlMjIlM0ElMjJybHR%2BMTY5Nzc5Njc5MX5sYW5kfjJfMTY0NjdfZGlyZWN0XzQ0OWU4MzBmMmE0OTU0YmM2ZmVjNWMxODFlYzI4Zjk0JTIyJTJDJTIyc2l0ZUlkJTIyJTNBNDAxMzElN0Q%3D
+Veeam Software~https://www.linkedin.com/company/veeam-software/jobs/
+Hotel Engine~https://boards.greenhouse.io/hotelengine/
+Cohere Health~https://coherehealth.com/careers/
+Causal~https://jobs.ashbyhq.com/pear
+Braze~https://www.braze.com/company/careers
+Personio~https://www.linkedin.com/company/personio/jobs/
+LaSalle Network~https://www.thelasallenetwork.com/job-search
+Suzy~https://www.linkedin.com/company/asksuzy/jobs/
+Roo~https://jobs.lever.co/roo/
+EagleView~https://www.linkedin.com/company/eagleview-technologies-inc/jobs/
+Pontosense~https://jobs.ashbyhq.com/Pontosense
+Guardsquare~https://boards.greenhouse.io/guardsquare/
+Crunchtime~https://www.crunchtime.com/open-positions
+~https://gohighlevel.com/careers
+ThreeFlow~https://boards.greenhouse.io/threeflow/
+Chronosphere~https://www.linkedin.com/company/chronosphereio/jobs/
+BetterCloud~https://www.bettercloud.com/job-board/
+Trolley~https://jobs.lever.co/trolley
+The Trade Desk~https://www.linkedin.com/company/the-trade-desk/jobs/
+SEVENROOMS~https://www.linkedin.com/company/sevenrooms/jobs/
+Form Energy~https://jobs.ashbyhq.com/formenergy/
+Apptega~https://www.apptega.com/careers/
+Westlake Financial~https://recruiting.ultipro.com/HAN1010/JobBoard/f03ae624-2195-4366-9876-a831dee4af59
+New Breed~https://www.newbreedrevenue.com/careers
+nth Venture~https://www.nthventure.com/careers
+Asana~https://asana.com/jobs/all
+Zello~https://zello.com/careers/
+Credit Karma~https://www.linkedin.com/company/credit-karma/jobs/
+BuzzFeed~https://www.linkedin.com/company/buzzfeed/jobs/
+Datavant~https://www.linkedin.com/company/datavant/jobs/
+Sprout Social, Inc.~https://sproutsocial.com/careers/open-positions/
+Walmart Connect~https://careers.walmart.com/results?q=Walmart%20Connect&page=1&sort=rank&expand=department,brand,type,rate&jobCareerArea=all
+Busuu~https://www.linkedin.com/company/busuu-com/jobs/
+Fenix24~https://www.linkedin.com/company/fenix24/jobs/
+MarketOne International~https://www.marketone.com/jobs
+Flosum~https://flosum.freshteam.com/jobs/
+Commure~https://www.commure.com/careers/
+Fair Square~https://jobs.ashbyhq.com/fairsquaremedicare/
+Impact Networking, LLC~https://careers.impactmybiz.com/search/jobs
+Insider.~https://jobs.lever.co/useinsider
+Soundstripe~https://app.soundstripe.com/careers
+Petal~https://petalmd.recruitee.com
+Consensus~https://jobs.lever.co/goconsensus
+TransPerfect~https://www.linkedin.com/company/transperfect/jobs/
+Investis Digital~https://investisdigital.bamboohr.com/jobs
+Brightly~https://recruiting.paylocity.com/recruiting/jobs/All/2e9b79ad-c442-43b2-89fe-4fecaa2fde04/Brightly-Software-Inc
+HG Insights~https://hginsights.com/about/hg-insights-careers
+Studio Science~https://studioscience.com/careers/
+Mutinex~https://www.linkedin.com/company/mutinex/jobs/
+Remote~https://www.linkedin.com/company/remote.com/jobs/
+Budderfly~https://www.budderfly.com/careers/
+Plum~https://www.plum.io/careers
+Curvature~https://www.curvature.com/about-us/careers/
+WalkMe™~https://www.walkme.com/careers_list/?region=Location
+Wiz~https://www.wiz.io/careers
+Straker~https://strakertranslations.bamboohr.com/careers
+Apexon~https://www.apexon.com/explore-jobs/
+FreightWaves~https://freightwavesinc.applytojob.com/apply
+Anthology Inc~https://www.linkedin.com/company/anthologyinc/jobs/
+Marqeta~https://www.linkedin.com/company/marqeta/jobs/
+Boeing~https://www.linkedin.com/company/boeing/jobs/
+Ava Labs~https://www.linkedin.com/company/avalabsofficial/jobs/
+Authorized Acquisitions~https://aa-medical.rippling-ats.com/
+7shifts: Team Management for Restaurants~https://boards.greenhouse.io/7shifts/
+Rubrik~https://www.linkedin.com/company/rubrik-inc/jobs/
+Paper~https://paper.wd3.myworkdayjobs.com/Paper_Careers
+JPMorgan Chase & Co.~https://www.linkedin.com/company/jpmorganchase/jobs/
+DexCare~https://jobs.lever.co/dexcarehealth
+ClickBank~https://www.linkedin.com/company/clickbank/jobs/
+StarRez, Inc.~https://www.starrez.com/company/careers
+GRIN~https://grin.co/careers/jobs/
+Breezy HR~https://breezy.hr/attract
+Unbabel~https://careers.unbabel.com/
+Redpanda Data~https://redpanda.com/careers
+Netskope~https://www.netskope.com/company/careers/open-positions
+Sift~https://sift.com/careers
+Revolut~https://www.linkedin.com/company/revolut/jobs/
+HME~https://www.hme.com/careers/
+Pigment~https://jobs.lever.co/pigment/
+Happeo~https://jobs.ashbyhq.com/happeo/
+Groundswell Cloud Solutions, A GyanSys Company~https://www.linkedin.com/company/groundswellcloud/jobs/
+Biofire~https://www.linkedin.com/company/biofire/jobs/
+Fetch~https://www.linkedin.com/company/fetch-rewards/jobs/
+EquipmentShare~https://www.linkedin.com/company/equipmentshare/jobs/
+Apex Systems~https://www.apexsystems.com/search-results-usa
+Anomalo~https://www.anomalo.com/jobs
+Cryptio~https://www.linkedin.com/company/cryptio/jobs/
+Via~https://www.linkedin.com/company/ridewithvia/jobs/
+Signifyd~https://boards.greenhouse.io/signifyd95
+Tropic~https://boards.greenhouse.io/tropic
+Expel~https://expel.com/about/careers/
+Lumavate~https://www.lumavate.com/company/careers
+Bevi~https://bevi.co/careers/
+Echobot~https://www.echobot.com/career/
+Nue.io~https://www.nue.io/company/careers/
+ClassDojo~https://www.classdojo.com/jobs/
+Digital.ai~https://digital.ai/current-job-openings
+ModMed~https://www.modmed.com/company/careers/
+CTO.ai~https://cto.ai/careers
+McKesson~https://www.linkedin.com/company/mckesson/jobs/
+Connection~https://www.linkedin.com/company/connection-it/jobs/
+Improbable~https://jobs.lever.co/improbable/
+DrFirst, Inc.~https://careers-drfirst.icims.com/jobs/2023/architect/job
+Clutch~https://clutch.co/careers
+Atomic Invest~https://boards.greenhouse.io/atomicvest
+Blackbaud~https://www.linkedin.com/company/blackbaud/jobs/
+ROLLER~https://www.linkedin.com/company/roller/jobs/
+Gameloft~https://www.linkedin.com/company/gameloft/jobs/
+Episode Six~https://www.linkedin.com/company/episode-six/jobs/
+Plug and Play Tech Center~https://www.linkedin.com/company/plug-and-play-tech-center/jobs/
+Jackpot.com~https://www.jackpot.com/careers
+CaptivateIQ~https://jobs.lever.co/captivateiq/
+Tricentis~https://www.linkedin.com/company/tricentis/jobs/
+Whip Around~https://www.linkedin.com/company/whip-around/jobs/
+CARTO~https://jobs.lever.co/cartodb
+Acronis~https://www.linkedin.com/company/acronis/jobs/
+Automox~https://jobs.lever.co/automox/
+Kobiton~https://kobiton.com/careers/
+TripActions~https://tripactions.com/job-openings
+Profisee~https://profisee.com/job-openings/
+Abridge~https://jobs.lever.co/abridge/
+Ashby~https://www.ashbyhq.com/careers
+Icertis~https://jobs.lever.co/icertis/
+Intuit~https://www.linkedin.com/company/intuit/jobs/
+UP.Partners~https://axiomspace.bamboohr.com/careers
+Fusion Worldwide~https://www.linkedin.com/company/fusion-worldwide/jobs/
+XSELL Technologies~https://xselltechnologies.applytojob.com
+Vista Packaging and Logistics~https://secure.entertimeonline.com/ta/VistaPackaging.careers?CareersSearch
+Mastercard~https://www.linkedin.com/company/mastercard/jobs/
+Naologic~https://naologic.com/careers/jobs
+Vareto~https://boards.greenhouse.io/vareto/
+Freddie Mac~https://www.linkedin.com/company/freddie-mac/jobs/
+HighRadius~https://www.highradius.com/about/careers/
+Verkada~https://jobs.lever.co/verkada/
+MassMutual~https://www.linkedin.com/company/massmutual-financial-group/jobs/
+Virtualitics, Inc.~https://virtualitics.breezy.hr/
+Ramp~https://jobs.ashbyhq.com/ramp
+Progyny, Inc.~https://www.linkedin.com/company/progyny/jobs/
+Torch Dental~https://jobs.lever.co/torchdental
+Revenue Analytics, Inc.~https://jobs.lever.co/revenueanalytics/
+Sees Candy Shops Inc~https://sees.wd1.myworkdayjobs.com/Sees_Candies
+Synthace~https://jobs.lever.co/synthace/
+Uptycs~https://www.uptycs.com/about/career
+Xembly~https://www.xembly.com/jobs
+Fluency - Advertising Automation Platform~https://fluency.applytojob.com
+Coconut Software~https://www.coconutsoftware.com/careers/
+Xendoo Online Bookkeeping & Accounting~https://www.linkedin.com/company/xendoo/jobs/
+CrowdStrike~https://www.linkedin.com/company/crowdstrike/jobs/
+Quorum~https://www.quorum.us/about/careers/
+Sila~https://silamoney.applytojob.com
+SYSPRO USA~https://www.linkedin.com/company/syspro-usa/jobs/
+Seenons~https://jobs.seenons.com/
+IZEA~https://izea.com/company/careers/apply-to-join-izea/
+Awesome Motive, Inc.~https://awesomemotive.com/careers/
+Wistia~https://wistia.com/jobs
+Partly~https://www.partly.com/careers/open-roles
+Lumafield~https://jobs.lever.co/lumafield/
+MycoWorks~https://boards.greenhouse.io/mycoworks/
+Global Laser Enrichment~https://www.gle-us.com/careers/
+Traction Rec~https://www.tractionrec.com/careers
+Chicory~https://boards.greenhouse.io/chicory
+Cority~https://jobs.lever.co/cority/
+FLEX College Prep~https://jobs.lever.co/flexcollegeprep/
+Esusu~https://esusurent.com/careers/
+Sysdig~https://boards.greenhouse.io/sysdig/
+Sonendo, Inc.~https://careers-sonendo.icims.com/jobs/intro?hashed=-626009781&mobile=false&width=1425&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240
+Rendered.ai~https://rendered.ai/about/
+Rokt~https://www.rokt.com/careers
+OneCause~https://jobs.jobvite.com/onecause/
+CloudTalk~https://www.cloudtalk.io/careers/
+MachineMetrics~https://www.machinemetrics.com/careers
+Atlantic Data Security, LLC~https://www.linkedin.com/jobs/search/?currentJobId=3656420315&f_C=5082062&geoId=92000000&originToLandingJobPostings=3656420315
+CMC Global Company Limited.~https://www.linkedin.com/company/cmc-global-company-limited/jobs/
+Salute Safety~https://www.salutesafety.com/join-our-team
+Stout Systems~https://www.stoutsystems.com/job-search-michigan-and-beyond/
+WorkTango Inc.~https://www.worktango.com/careers#open-roles
+Information Security Media Group (ISMG)~https://ismg.careers/careers
+Lightpath~https://www.linkedin.com/company/lightpath/jobs/
+Outreach~https://jobs.lever.co/outreach/
+Warner Bros. Discovery~https://www.linkedin.com/company/warner-bros-discovery/jobs/
+Cognism~https://www.cognism.com/careers
+Dealpath~https://www.dealpath.com/careers/
+Olo~https://jobs.lever.co/olo/
+Design Interactive, Inc.~https://recruiting.paylocity.com/recruiting/jobs/All/7e700d27-1c17-4273-9855-c424190be932/Design-Interactive-Inc
+Kimoby~https://www.kimoby.com/careers
+Redaptive, Inc~https://jobs.lever.co/redaptiveinc/
+Plentific~https://www.plentific.com/en-us/careers
+Donut~https://jobs.lever.co/donut
+Fidus Systems~https://fidus.com/careers/
+Apaleo~https://boards.greenhouse.io/apaleo/
+OSF Digital~https://osf.digital/careers/jobs
+L3Harris Technologies~https://www.linkedin.com/company/l3harris-technologies/jobs/
+ComplYant~https://complyant.breezy.hr/
+Vicasso | We Accelerate Service~https://www.vicasso.com/company/careers
+Cordial~https://cordial.com/careers
+Centric Software~https://www.centricsoftware.com/careers/
+Expedia Group~https://expediagroup.com/careers/default.aspx
+Sounder~https://jobs.lever.co/sounder/
+Multiverse~https://www.linkedin.com/company/joinmultiverse/jobs/
+Flex Technology Group~https://flextgcareers.ttcportals.com/jobs/search
+Evisort~https://www.linkedin.com/company/evisort/jobs/
+WeTravel~https://jobs.wetravel.com/
+XTM International~https://careers.xtm.cloud/
+RevPartners~https://revpartners.applytojob.com
+PerformYard~https://www.linkedin.com/company/performyard/jobs/
+Seequent~https://seequent.csod.com/ux/ats/careersite/1/home?c=seequent
+Trulioo~https://www.trulioo.com/apply
+Plate IQ~https://www.linkedin.com/company/plateiq/jobs/
+GoLinks~https://www.golinks.io/careers_list.php
+Veeva Systems~https://careers.veeva.com/job-search-results/
+Cambridge Systematics, Inc.~https://camsys.com/careers-and-culture
+Lodgify~https://jobs.lever.co/lodgify/
+OwnBackup~https://www.ownbackup.com/careers/
+Smaato (Now part of Verve Group)~https://vervegroup.recruitee.com/
+Dun & Bradstreet~https://www.linkedin.com/company/dun-&-bradstreet/jobs/
+Other World Computing~https://owc.applytojob.com/apply
+Sonatype~https://jobs.lever.co/sonatype/
+Cloud Software Group~https://careers.cloud.com/jobs/search
+Amaze~https://jobs.lever.co/amaze/
+Marble~https://jobs.lever.co/Medchart
+DigiCert~https://www.digicert.com/careers
+Axuall~https://boards.greenhouse.io/axuall
+Stack Overflow~https://stackoverflow.com/jobs/companies?so_medium=stackoverflow&so_source=SiteNav
+Learn Amp | B Corp™~https://learnamp.com/careers
+AT&T~https://www.linkedin.com/company/att/jobs/
+Secureframe~https://jobs.lever.co/secureframe/
+Backbase~https://www.backbase.com/careers/jobs
+Audacy, Inc.~https://www.linkedin.com/company/audacy-inc/jobs/
+SIO Logistics~https://www.linkedin.com/company/senditover/jobs
+Avalara~https://www.linkedin.com/company/avalara/jobs/

--- a/job_crawler.py
+++ b/job_crawler.py
@@ -19,7 +19,7 @@ PROCESSED_URLS = set()
 def getURL():
     '''Tier 1: The First Scrape
     Extracts URLs from the defined global URL variable.
-    
+
     Parameters:
     - N/A
 
@@ -35,7 +35,8 @@ def getURL():
         print("Page title couldn't be found")
 
     initial_response = driver.page_source
-    global PROCESSED_URLS 
+    print("INITIAL RESPONSE", type(initial_response))
+    global PROCESSED_URLS
     extract_and_save(initial_response, PROCESSED_URLS)
     scrollable_div = driver.find_element(By.CSS_SELECTOR, ".scrollOverlay.antiscroll-wrap")
 
@@ -45,7 +46,7 @@ def getURL():
     no_change_counter = 0
     max_no_change = 3  # Adjust based on your preference
 
-    while  len(PROCESSED_URLS) < record_number:
+    while len(PROCESSED_URLS) < record_number:
         # Scroll down by 850px
         actions = ActionChains(driver)
         actions.move_to_element(scrollable_div).click().send_keys(Keys.PAGE_DOWN).perform()
@@ -75,7 +76,7 @@ def getURL():
 
     with open('hrefs.txt','a') as file:
         for url in PROCESSED_URLS:
-            file.write(url + '\n')
+            file.write(url[0] + "~" + url[1] + '\n')
 
     driver.quit()
 

--- a/utils.py
+++ b/utils.py
@@ -28,16 +28,25 @@ def extract_and_save(response, url_set):
 
     Parameters:
     - selenium page source
+    - set to hold processed company names and job link urls
+        -set will be set of tuples (company_name: str, job_url: str)
 
     Returns:
-    - Adds href to the "PROCESSED_URLS" set.
+    - the filled set, to be procssed by the calling parent
     '''
     soup = BeautifulSoup(response, 'html.parser')
-    all_spans = soup.find_all('span', class_='truncate noevents')
-    if all_spans:
-        for span in all_spans:
-            a_tag = span.find_parent('a')
-            # print(a_tag['href'])
-            url_set.add(a_tag['href'])
+
+    #access all of the dataRows from "dataLeftPaneInnerContent paneInnerContent"
+    all_rows = soup.find_all(attrs={"data-testid":"data-row"})
+
+    if all_rows:
+        for row in all_rows:
+            company_name = row.find(attrs={"data-columnindex":"0"}).get_text()
+            jobs_link = row.find(attrs={"data-columnindex":"2"}).a.get('href')
+
+            company_info = (company_name, jobs_link)
+
+            url_set.add(company_info)
         return url_set
+
 


### PR DESCRIPTION
-updated extract_and_save to pull both the company name and job url on one pass 
-update hrefs to be in format of company_name~url
-update count.py to account for new structure of hrefs

I tried to be fancy and use: https://www.conventionalcommits.org/en/v1.0.0/ verbiage for the commit.